### PR TITLE
add CI docs build test for PRs

### DIFF
--- a/.github/workflows/test-docs-pr.yml
+++ b/.github/workflows/test-docs-pr.yml
@@ -1,0 +1,29 @@
+name: test-docs-build
+
+# Only run this when the master branch changes
+on:
+  pull_request:
+    branches:
+      - main
+
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+jobs:
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install jupyter-book sphinx-autodoc-typehints
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build ./docs


### PR DESCRIPTION
This PR adds a github actions workflow that builds the docs on PR.

closes #53 