### PR TITLE
update overview docs page and add stubs for getting started

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-        pip install mkdocs mkdocs-material mkdocstrings[python]
+        pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-video
 
     # Build the book
     - name: Build the book

--- a/.github/workflows/test-docs-pr.yml
+++ b/.github/workflows/test-docs-pr.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-        pip install mkdocs mkdocs-material mkdocstrings[python]
+        pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-video
     # Build the book
     - name: Build the book
       run: |

--- a/docs/getting_started/developers.md
+++ b/docs/getting_started/developers.md
@@ -1,0 +1,4 @@
+# Geting started for developers
+
+- Explanations of the core concepts and manipulators.
+- Gallery of examples of plugins that depend on `napari-threedee`(WIP).

--- a/docs/getting_started/users.md
+++ b/docs/getting_started/users.md
@@ -1,0 +1,4 @@
+# Getting started for users
+
+- Tutorials
+- Gallery of examples of plugins that depend on `napari-threedee` (WIP).

--- a/docs/how_to/how_to.md
+++ b/docs/how_to/how_to.md
@@ -1,6 +1,0 @@
-# How-to guides
-
-The how-to guides provide instructions for common operations and use cases of `napari-threedee`.
-
-```{tableofcontents}
-```

--- a/docs/how_to/how_to_render_plane_manipulator.md
+++ b/docs/how_to/how_to_render_plane_manipulator.md
@@ -1,0 +1,6 @@
+# use the render plane manipulator
+
+## Summary
+
+This article explains how to use the render plane manipulator. The 
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,2 +1,35 @@
 # Overview
-napari-threedee is a collection of tools for 3D interactivity in napari.
+napari-threedee is a collection of tools for exploring, manipulating, and annotating your data in 3D. 
+
+![type:video](https://user-images.githubusercontent.com/1120672/206995875-4e71a25c-1cc5-44dd-86e1-bf912dc2d209.mov)
+
+## Installation
+
+`napari-threedee` is a `napari` plugin and thus requires `napari` to work. You can see the `napari` documentation for 
+[napari installation instructions](https://napari.org/stable/tutorials/fundamentals/installation.html). After you 
+have installed `napari`, you can install `napari-threedee` using the package manager of your choice using the commands 
+below.
+
+=== "pip"
+
+    ``` bash
+    pip install napari-threedee
+    ```
+
+=== "conda"
+
+    ``` bash
+    conda install -c napari-threedee
+    ```
+
+## Getting started
+
+### Users
+Do you have rich 3D (or more!) data that you want to explore and annotate? `napari-threedee` comes with a collection 
+of plugins for just that. Please see our [Getting started for users guide](getting_started/users.md) to get going.
+
+### Developers
+Are you developing an image processing workflow that requires exploration or annotation of multidimensional data? 
+`napari-threedee` has a collection of composable compoents for adding 3D interactivity to your workflow! To get 
+started, see our [Getting started for developers guide](getting_started/developers.md).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,11 @@ extra:
 
 nav:
   - index.md
+  - Getting started:
+    - 'for users': getting_started/users.md
+    - 'for developers': getting_started/developers.md
+  - How do I...:
+      - how_to/how_to_render_plane_manipulator.md
   - Explanations:
       - dev_guides/core_concepts.md
       - dev_guides/manipulators.md
@@ -117,7 +122,9 @@ plugins:
 
             ## experimental
             docstring_section_style: spacy  # or table/list/spacy
-
+  - mkdocs-video:
+      is_video: True
+      video_autoplay: True
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,9 +83,9 @@ nav:
       - dev_guides/core_concepts.md
       - dev_guides/manipulators.md
   - API:
-      - API/napari_utilities.md
-      - API/selection_utilities.md
-      - API/geometry_utilities.md
+      - api/napari_utilities.md
+      - api/selection_utilities.md
+      - api/geometry_utilities.md
 
 plugins:
   - search

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ dev =
 	mkdocs
 	mkdocs-materials
 	mkdocstrings[python]
+	mkdocs-video
 	pytest
 	pytest-qt
 

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -85,14 +85,11 @@ def get_mouse_position_in_displayed_dimensions(event) -> np.ndarray:
 
     Parameters
     ----------
-    layer : napari.layers.Layer
-        The layer to convert the coordinates to.
     event
         The mouse event.
+
     Returns
     -------
-    click_position_data_3d : np.ndarray
-        The click position in displayed data coordinates.
     click_dir_data_3d : np.ndarray
         The click direction in displayed data coordiantes
     """


### PR DESCRIPTION
This PR updates the landing page of the docs:
- add video
- add installation instructions
- add getting started section and stubs for the getting started pages