### PR TITLE
remove auto detection of light/dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,8 +17,7 @@ theme:
   name: material
   palette:
     # Palette toggle for light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: indigo
       accent: indigo
       toggle:
@@ -26,13 +25,13 @@ theme:
         name: Switch to dark mode
 
     # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    - scheme: slate
       primary: blue grey
       accent: blue grey
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to light mode
+
   features:
     - navigation.instant
     #- navigation.tabs


### PR DESCRIPTION
change the docs theme so that it defaults to light mode regardless of the system theme. I think it makes sense to give people the option, but we should heavily bias towards light mode since maintaining two nice looking themes is too much work...