### PR TITLE
override keybindings by default

### DIFF
--- a/src/napari_threedee/annotators/sphere_annotator.py
+++ b/src/napari_threedee/annotators/sphere_annotator.py
@@ -223,8 +223,12 @@ class SphereAnnotator(ThreeDeeModel):
                 callback=self._mouse_callback
             )
             self.points_layer.events.data.connect(self._on_point_data_changed)
-            self.viewer.bind_key('r', self._set_radius_from_mouse_event)
-            self.viewer.bind_key('n', self._enable_add_mode)
+            self.viewer.bind_key(
+                'r', self._set_radius_from_mouse_event, overwrite=True
+            )
+            self.viewer.bind_key(
+                'n', self._enable_add_mode, overwrite=True
+            )
             self.viewer.layers.selection.active = self.image_layer
 
     def _on_disable(self):
@@ -234,7 +238,7 @@ class SphereAnnotator(ThreeDeeModel):
         )
         if self.points_layer is not None:
             self.points_layer.events.data.disconnect(self._on_point_data_changed)
-        self.viewer.bind_key('n', None)
+        self.viewer.bind_key('n', None, overwrite=True)
 
     def _on_point_data_changed(self, event=None):
         self._update_spheres()

--- a/src/napari_threedee/annotators/spline_annotator.py
+++ b/src/napari_threedee/annotators/spline_annotator.py
@@ -236,7 +236,7 @@ class SplineAnnotator(ThreeDeeModel):
                 self.viewer.mouse_drag_callbacks, self._mouse_callback
             )
             self.points_layer.events.data.connect(self._on_point_data_changed)
-            self.viewer.bind_key('n', self.next_spline)
+            self.viewer.bind_key('n', self.next_spline, overwrite=True)
             self.viewer.layers.selection.active = self.image_layer
 
     def _on_disable(self):
@@ -247,7 +247,7 @@ class SplineAnnotator(ThreeDeeModel):
             self.points_layer.events.data.disconnect(
                 self._on_point_data_changed
             )
-        self.viewer.bind_key('n', None)
+        self.viewer.bind_key('n', None, overwrite=True)
 
     def _on_point_data_changed(self, event=None):
         if self.auto_fit_spline is True:

--- a/src/napari_threedee/annotators/surface_annotator.py
+++ b/src/napari_threedee/annotators/surface_annotator.py
@@ -229,7 +229,7 @@ class SurfaceAnnotator(ThreeDeeModel):
                 self.viewer.mouse_drag_callbacks, self._mouse_callback
             )
             self.points_layer.events.data.connect(self._on_point_data_changed)
-            self.viewer.bind_key('n', self.next_spline)
+            self.viewer.bind_key('n', self.next_spline, overwrite=True)
             self.viewer.layers.selection.active = self.image_layer
 
     def _on_disable(self):
@@ -240,7 +240,7 @@ class SurfaceAnnotator(ThreeDeeModel):
             self.points_layer.events.data.disconnect(
                 self._on_point_data_changed
             )
-        self.viewer.bind_key('n', None)
+        self.viewer.bind_key('n', None, overwrite=True)
 
     def _on_point_data_changed(self, event=None):
         if self.auto_fit_spline is True:

--- a/src/napari_threedee/visualization/camera_spline.py
+++ b/src/napari_threedee/visualization/camera_spline.py
@@ -298,7 +298,7 @@ class CameraSpline(ThreeDeeModel):
         self.spline_annotator_model.enabled = True
 
         # disable the key binding to switch to the next spline index
-        self.viewer.bind_key('n', None)
+        self.viewer.bind_key('n', None, overwrite=True)
 
     def stop_spline_annotation(self):
         """Callback called when exiting ANNOTATION mode."""


### PR DESCRIPTION
this is useful when reusing annotators but replacing data/layers for different datasets

cc @kevinyamauchi 