### PR TITLE
Enable video looping in docs pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ plugins:
   - mkdocs-video:
       is_video: True
       video_autoplay: True
+      video_loop: True
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
I'd like to propose automatically looping videos in the napari-threedee docs (until the user clicks to stop it).

The [render plane manipulator docs page](https://napari-threedee.github.io/how_to/render_plane_manipulator/) includes a 4 second video. Others are a little longer (eg: the main page video is 15 seconds long), but it's easy to miss, especially when you're also trying to read the text paragraphs as well.