### PR TITLE
swap example mesh

### DIFF
--- a/examples/library/mesh_headlight.py
+++ b/examples/library/mesh_headlight.py
@@ -1,32 +1,23 @@
-from nilearn import datasets
-from nilearn import surface
-
 import napari
+import numpy as np
+from vispy.io import load_data_file, read_mesh
 
 from napari_threedee.visualization._qt.qt_lighting_control import QtLightingControlWidget
 
 
 # Fetch datasets - this will download dataset if datasets are not found
-nki_dataset = datasets.fetch_surf_nki_enhanced(n_subjects=1)
-fsaverage = datasets.fetch_surf_fsaverage()
+vertices, faces, _, _ = read_mesh(load_data_file('orig/triceratops.obj.gz'))
 
-# Load surface data and resting state time series from nilearn
-brain_vertices, brain_faces = surface.load_surf_data(fsaverage['pial_left'])
-brain_vertex_depth = surface.load_surf_data(fsaverage['sulc_left'])
-timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
-
-# nilearn provides data as n_vertices x n_timepoints, but napari requires the
-# vertices axis to be placed last to match NumPy broadcasting rules
-timeseries = timeseries.transpose((1, 0))
+# put the mesh right side up, scale it up (napari#3477) and fix faces handedness
+vertices *= -100
+faces = faces[:, ::-1]
+vertex_values = np.ones((len(vertices),))
 
 # create an empty viewer
 viewer = napari.Viewer(ndisplay=3)
 
-# add the mri
-viewer.add_surface((brain_vertices, brain_faces, brain_vertex_depth), name='base')
-viewer.add_surface((brain_vertices, brain_faces, timeseries),
-                    colormap='turbo', opacity=0.9,
-                    contrast_limits=[-1.5, 3.5], name='timeseries')
+# add the mesh
+viewer.add_surface((vertices, faces, vertex_values), name='triceratops')
 
 lighting_control_widget = QtLightingControlWidget(viewer=viewer)
 viewer.window.add_dock_widget(widget=lighting_control_widget)

--- a/examples/plugin/mesh_headlight.py
+++ b/examples/plugin/mesh_headlight.py
@@ -1,39 +1,23 @@
-try:
-    from nilearn import datasets
-    from nilearn import surface
-
-except ImportError:
-    raise ImportError("this example requires nilearn. pip install nilearn")
-
-
 import napari
-
-from napari_threedee.visualization._qt.qt_lighting_control import QtLightingControlWidget
+import numpy as np
+from vispy.io import load_data_file, read_mesh
 
 
 # Fetch datasets - this will download dataset if datasets are not found
-nki_dataset = datasets.fetch_surf_nki_enhanced(n_subjects=1)
-fsaverage = datasets.fetch_surf_fsaverage()
+vertices, faces, _, _ = read_mesh(load_data_file('orig/triceratops.obj.gz'))
 
-# Load surface data and resting state time series from nilearn
-brain_vertices, brain_faces = surface.load_surf_data(fsaverage['pial_left'])
-brain_vertex_depth = surface.load_surf_data(fsaverage['sulc_left'])
-timeseries = surface.load_surf_data(nki_dataset['func_left'][0])
-
-# nilearn provides data as n_vertices x n_timepoints, but napari requires the
-# vertices axis to be placed last to match NumPy broadcasting rules
-timeseries = timeseries.transpose((1, 0))
+# put the mesh right side up, scale it up (napari#3477) and fix faces handedness
+vertices *= -100
+faces = faces[:, ::-1]
+vertex_values = np.ones((len(vertices),))
 
 # create an empty viewer
 viewer = napari.Viewer(ndisplay=3)
 
-# add the mri
-viewer.add_surface((brain_vertices, brain_faces, brain_vertex_depth), name='base')
-viewer.add_surface((brain_vertices, brain_faces, timeseries),
-                    colormap='turbo', opacity=0.9,
-                    contrast_limits=[-1.5, 3.5], name='timeseries')
+# add the mesh
+viewer.add_surface((vertices, faces, vertex_values), name='triceratops')
 
-lighting_control_widget = QtLightingControlWidget(viewer=viewer)
+# open the plugin
 viewer.window.add_plugin_dock_widget(
     plugin_name="napari-threedee", widget_name="mesh lighting controls"
 )


### PR DESCRIPTION
The nilearn library is not compatible with numpy > 1.24, so I am swapping out the mesh in the `mesh_headlight.py` example for the triceratops from vispy.

closes #103 cc @GenevieveBuckley 