### PR TITLE
Fix empty PathAnnotator points layer for ndim > 3

### DIFF
--- a/docs/examples/plugin/spline_annotator_plugin.py
+++ b/docs/examples/plugin/spline_annotator_plugin.py
@@ -45,7 +45,7 @@ viewer.add_image(
 
 # add plugin dock widget to viewer
 viewer.window.add_plugin_dock_widget(
-    plugin_name="napari-threedee", widget_name="sphere annotator"
+    plugin_name="napari-threedee", widget_name="path annotator"
 )
 
 # run napari

--- a/src/napari_threedee/annotators/_tests/test_spline_annotator.py
+++ b/src/napari_threedee/annotators/_tests/test_spline_annotator.py
@@ -26,22 +26,29 @@ def test_add_point(spline_annotator):
     # add points, make sure filament id in feature table matches the annotator
     points_layer.add([1, 2, 3, 4])
     assert len(points_layer.data) == 1
-    assert points_layer.features[label][0] == spline_annotator.active_spline_id
+    assert points_layer.features[label][0] == 0
 
-    # change filemanet_id in annotator, add point, check matches
-    spline_annotator.active_level_id = 534
+    # change filamanet_id in annotator, add point, check matches
     points_layer.add([2, 3, 4, 5])
-    assert points_layer.features[label][1] == spline_annotator.active_spline_id
+    assert points_layer.features[label][1] == 0
+
+    # create new path, make sure id advanced
+    spline_annotator.activate_new_path_mode()
+    points_layer.add([2, 3, 4, 5])
+    assert points_layer.features[label][2] == 1
 
 
 def test_get_colors(spline_annotator):
     """Test getting spline colors from the annotator."""
+    # add a point. the first spline gets id 0
     points_layer = spline_annotator.points_layer
-    spline_annotator.active_spline_id = 0
     points_layer.add([1, 2, 3, 4])
-    spline_annotator.active_spline_id = 1
+
+    # create a new spline, this advances the spline id to 1
+    spline_annotator.activate_new_path_mode()
     points_layer.add([2, 3, 4, 5])
 
     spline_colors = spline_annotator._get_path_colors()
     for spline_id in (0, 1):
+        # check that both spline ids are in the colors dict
         assert spline_id in spline_colors

--- a/src/napari_threedee/annotators/_tests/test_spline_annotator.py
+++ b/src/napari_threedee/annotators/_tests/test_spline_annotator.py
@@ -31,11 +31,13 @@ def test_add_point(spline_annotator):
     # change filamanet_id in annotator, add point, check matches
     points_layer.add([2, 3, 4, 5])
     assert points_layer.features[label][1] == 0
+    assert spline_annotator.active_path_id == 0
 
     # create new path, make sure id advanced
     spline_annotator.activate_new_path_mode()
     points_layer.add([2, 3, 4, 5])
     assert points_layer.features[label][2] == 1
+    assert spline_annotator.active_path_id == 1
 
 
 def test_get_colors(spline_annotator):

--- a/src/napari_threedee/annotators/paths/annotator.py
+++ b/src/napari_threedee/annotators/paths/annotator.py
@@ -58,8 +58,8 @@ class PathAnnotator(N3dComponent):
 
     def _create_points_layer(self) -> Points:
         from napari_threedee.data_models import N3dPaths
-        layer = N3dPaths(data=[]).as_layer()
-        return layer
+        ndim = self.image_layer.data.ndim
+        return N3dPaths.create_empty_layer(ndim=ndim)
 
     def _create_shapes_layer(self) -> Shapes:
         return Shapes(

--- a/src/napari_threedee/annotators/paths/annotator.py
+++ b/src/napari_threedee/annotators/paths/annotator.py
@@ -35,6 +35,10 @@ class PathAnnotator(N3dComponent):
 
         self.enabled = enabled
 
+    @property
+    def active_path_id(self):
+        return self.points_layer.current_properties[PATH_ID_FEATURES_KEY][0]
+
     def activate_new_path_mode(self, event=None) -> None:
         if self.points_layer is None:
             return

--- a/src/napari_threedee/data_models/paths.py
+++ b/src/napari_threedee/data_models/paths.py
@@ -128,6 +128,31 @@ class N3dPaths(N3dDataModel):
         n3d_zarr.attrs[ANNOTATION_TYPE_KEY] = PATH_ANNOTATION_TYPE_KEY
         n3d_zarr.attrs[PATH_ID_FEATURES_KEY] = list(self.spline_ids)
 
+    @classmethod
+    def create_empty_layer(cls, ndim: int):
+        """Create an empty path annotator points layer.
+
+        Parameters
+        ----------
+        ndim : int
+            The dimensionality of the empty points layer.
+            Generally, this should match the image layer being
+            annotated.
+
+        Returns
+        -------
+        layer : napari.layers.Points
+            The napari Points layer initialized for path annotation.
+        """
+        # workaround for napari/napari#4213
+        dummy_data = np.zeros((ndim,))
+        n3d_paths = cls(data=[N3dPath(data=dummy_data)])
+        layer = n3d_paths.as_layer()
+        layer.selected_data = {0}
+        layer.remove_selected()
+        return layer
+
+
     def __getitem__(self, idx: int) -> N3dPath:
         return self.data[idx]
 


### PR DESCRIPTION
This closes #129 . I added a class method that initializes the PathAnnotator points layer for a given ndim. I also added a read-only `PathAnnotator.active_path_id` property (just returns the current_properties value from the points layer) since I this is useful information to be able to easily get.