### PR TITLE
update mkdocs versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,8 @@ napari.manifest =
 
 [options.extras_require]
 dev = 
-	mkdocs==1.2.4 # Pinned due to issue https://github.com/smarie/mkdocs-gallery/issues/57
-	mkdocs-gallery
+	mkdocs
+	mkdocs-gallery>0.7.6
 	mkdocs-material
 	mkdocstrings[python]
 	mkdocs-video


### PR DESCRIPTION
`mkdocs-gallery` was updated so we no longer need to pin `mkdocs`

closes #113 