### PR TITLE
Add `visibility` flag to manifest

### DIFF
--- a/src/napari_threedee/napari.yaml
+++ b/src/napari_threedee/napari.yaml
@@ -1,5 +1,6 @@
 name: napari-threedee
 schema_version: 0.1.0
+visibility: hidden
 contributions:
   commands:
     # Annotators


### PR DESCRIPTION
Hi folks, I noticed you had `visibility: 'hidden'` set in your napari hub config. I'm in the process of updating the napari hub to use the `visibility` flag in the manifest, so I've added this flag there as well. 

The napari hub changes aren't released yet, but this will be a hard deprecation of the flag in its current location, so I've not yet removed it from `.napari-hub/config.yml`. This way we don't risk your plugin accidentally being visible while we switch over to the manifest flag. 

Once changes to the napari hub are all released I'll make a follow up PR to remove the unused file. Let me know if there's any issues 😊 