### PR TITLE
import from qtpy not PyQt5

### DIFF
--- a/src/napari_threedee/_backend/threedee_widget_base.py
+++ b/src/napari_threedee/_backend/threedee_widget_base.py
@@ -1,7 +1,7 @@
 from typing import Type
 
 import napari
-from PyQt5.QtWidgets import QWidget, QPushButton, QVBoxLayout
+from qtpy.QtWidgets import QWidget, QPushButton, QVBoxLayout
 from napari.utils.events import Event
 
 from napari_threedee._backend.threedee_model import N3dComponent


### PR DESCRIPTION
When using pyside2 napari backend, napari-threedee widgets don't work with:
```
RuntimeError: Failed to import command at 'napari_threedee.dock_widgets:QtPointAnnotatorWidget': No module named 'PyQt5'
```
In this PR, the hard-coded import from PyQt5 is changed to qtpy, see also:
https://napari.org/stable/plugins/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies


