### PR TITLE
[Bugfix] Use SplineSampler instead of PathAnnotator for `set_view_button` of spline_camera

### DIFF
--- a/src/napari_threedee/visualization/camera_spline.py
+++ b/src/napari_threedee/visualization/camera_spline.py
@@ -188,12 +188,12 @@ class CameraSpline(N3dComponent):
 
     def calculate_transform_from_spline_tangent_to_view_direction(self):
         current_view_direction = self.viewer.camera.view_direction
-        n3d_metadata = self.spline_annotator_model.points_layer.metadata[N3D_METADATA_KEY]
-        spline_dict = n3d_metadata[PathAnnotator.SPLINES_KEY]
+        paths = N3dPaths.from_layer(self.spline_annotator_model.points_layer)
 
         # only one spline
-        spline_object = spline_dict[0]
-        spline_tangent = np.squeeze(spline_object._sample_backbone(u=[self.current_spline_coordinate], derivative=1))
+        spline_object = paths[0]
+        spline_sampler = SplineSampler(points=spline_object.data)
+        spline_tangent = np.squeeze(spline_sampler(u=[self.current_spline_coordinate], derivative=1))
         spline_tangent_displayed = spline_tangent[list(self.viewer.dims.displayed)]
 
         self.view_direction_transformation = rotation_matrix_from_vectors_3d(


### PR DESCRIPTION
Closes https://github.com/napari-threedee/napari-threedee/issues/146

So I think this was simply missed in the refactoring of https://github.com/napari-threedee/napari-threedee/pull/96
The `set from current view` button was still referencing code that had been removed.

In this PR, I remove the old PathAnnotator code and use SplineSampler, analogous to the code used further down, in `set_camera_position`.
As far as I can tell this is working correctly, when comparing this branch vs. 1aa50dd which was before the refactor.
