### PR TITLE
[bugfix] change layer.interactive to layer.mouse_pan

### DIFF
--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -96,7 +96,7 @@ class NapariManipulatorBackend:
 
     def _mouse_callback(self, layer, event):
         """Mouse call back for selecting and dragging a manipulator."""
-        initial_layer_interactive = layer.interactive
+        initial_layer_interactive = layer.mouse_pan
         click_position_data_3d, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(
             layer, event
         )
@@ -105,7 +105,7 @@ class NapariManipulatorBackend:
             return
 
         # setup...
-        layer.interactive = False
+        layer.mouse_pan = False
         self.is_dragging = True
         self._update_colors()
 
@@ -127,7 +127,7 @@ class NapariManipulatorBackend:
         # reset manipulator visual and layer interactivity to original state
         self.manipulator_model.selected_axis_id = None
         self._update_colors()
-        layer.interactive = initial_layer_interactive
+        layer.mouse_pan = initial_layer_interactive
         self.is_dragging = False
 
     def _drag_manager_from_click(


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/152

In https://github.com/napari/napari/pull/5701 (released in 0.4.18) the layer property `interactive` was deprecated. This results in a spam of FutureWarnings, which are annoying if using napari-threedee in a notebook.

In this PR, I replace the usage of `layer.interactive` with `layer.mouse_pan`, as instructed by https://github.com/napari/napari/pull/5701