### PR TITLE
[docs, bugfix] Fix developers getting started broken links

### DIFF
--- a/docs/getting_started/developers.md
+++ b/docs/getting_started/developers.md
@@ -2,6 +2,6 @@
 
 To get started developing plugins or applications that depend on napari-threedee, we recommend viewing our explanatory documentation the describes how the different components are designed:
 
-- [Explanation of the core concepts](../dev_guides/core_concepts)
-- [Explanation of the manipulators](../dev_guides/manipulators)
-- [Explanation of the annotation specifications](../annotations/specifications)
+- [Explanation of the core concepts](../dev_guides/core_concepts.md)
+- [Explanation of the manipulators](../dev_guides/manipulators.md)
+- [Explanation of the annotation specifications](../annotations/specifications.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,6 @@ of plugins for just that. Please see our [Getting started for users guide](getti
 
 ### Developers
 Are you developing an image processing workflow that requires exploration or annotation of multidimensional data? 
-`napari-threedee` has a collection of composable compoents for adding 3D interactivity to your workflow! To get 
+`napari-threedee` has a collection of composable components for adding 3D interactivity to your workflow! To get 
 started, see our [Getting started for developers guide](getting_started/developers.md).
 


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/156

Fixes the broken links by linking to the markdown properly.
Also noticed a typo in the index, so I fixed that too!