### PR TITLE
Fix path annotator color behavior and mkdocs build

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -73,10 +73,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: tlambert03/setup-qt-libs@v1
     # Install dependencies
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install "PyOpenGL<3.1.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,8 @@ napari.manifest =
 	napari-threedee = napari_threedee:napari.yaml
 
 [options.extras_require]
-dev = 
+dev =
+	lxml[html_clean]>5 # https://github.com/napari/napari/pull/6799
 	mkdocs
 	mkdocs-gallery>0.7.6
 	mkdocs-material

--- a/src/napari_threedee/annotators/paths/annotator.py
+++ b/src/napari_threedee/annotators/paths/annotator.py
@@ -7,7 +7,10 @@ from typing import Optional, Dict
 from napari_threedee._backend.threedee_model import N3dComponent
 from napari_threedee.annotators.paths.constants import (
     PATH_ID_FEATURES_KEY,
-    PATH_COLOR_FEATURES_KEY,
+    PATH_COLOR_FEATURES_KEY_0,
+    PATH_COLOR_FEATURES_KEY_1,
+    PATH_COLOR_FEATURES_KEY_2,
+    PATH_COLOR_FEATURES_KEY_3,
 )
 from napari_threedee.utils.mouse_callbacks import add_point_on_plane
 from napari_threedee.utils.napari_utils import add_mouse_callback_safe, \
@@ -109,14 +112,29 @@ class PathAnnotator(N3dComponent):
             self._draw_paths()
 
     def _get_path_colors(self) -> Dict[int, np.ndarray]:
-        self.points_layer.features[PATH_COLOR_FEATURES_KEY] = \
-            list(self.points_layer.face_color)
+        face_colors = self.points_layer.face_color
+        if len(face_colors) == 0:
+            # if no colors, return empty dict
+            return dict()
+
+        self.points_layer.features[PATH_COLOR_FEATURES_KEY_0] = face_colors[:, 0]
+        self.points_layer.features[PATH_COLOR_FEATURES_KEY_1] = face_colors[:, 1]
+        self.points_layer.features[PATH_COLOR_FEATURES_KEY_2] = face_colors[:, 2]
+        self.points_layer.features[PATH_COLOR_FEATURES_KEY_3] = face_colors[:, 3]
+
         grouped_points_features = self.points_layer.features.groupby(
             PATH_ID_FEATURES_KEY
         )
         path_colors = dict()
         for path_id, path_df in grouped_points_features:
-            path_colors[path_id] = path_df[PATH_COLOR_FEATURES_KEY].iloc[0]
+            path_colors[path_id] = path_df[
+                [
+                    PATH_COLOR_FEATURES_KEY_0,
+                    PATH_COLOR_FEATURES_KEY_1,
+                    PATH_COLOR_FEATURES_KEY_2,
+                    PATH_COLOR_FEATURES_KEY_3
+                ]
+            ].iloc[0]
         return path_colors
 
     def _clear_shapes_layer(self):

--- a/src/napari_threedee/annotators/paths/constants.py
+++ b/src/napari_threedee/annotators/paths/constants.py
@@ -13,4 +13,7 @@ COLOR_CYCLE = [
     '#17becf',
 ]
 PATH_ID_FEATURES_KEY = "path_id"
-PATH_COLOR_FEATURES_KEY = "spline_color"
+PATH_COLOR_FEATURES_KEY_0 = "spline_color_0"
+PATH_COLOR_FEATURES_KEY_1 = "spline_color_1"
+PATH_COLOR_FEATURES_KEY_2 = "spline_color_2"
+PATH_COLOR_FEATURES_KEY_3 = "spline_color_3"


### PR DESCRIPTION
napari 0.4.19 updated the point coloring API, which broke the path annotator (#158). In short, we were storing numpy arrays in a column of the features table, which tripped up the napari coloring code (thanks for the sleuthing, @psobolewskiPhD !). I've updated it so that we store each element of the RGBA colors as individual columns, which seems to fix the error. (it's probably better practice to not store arrays in the columns anyway 😬 )

Also, this adds the `html_clean` dependency required to do the notebook display used in our docs build: https://github.com/napari/napari/pull/6799 


cc @psobolewskiPhD , @alisterburt 