### PR TITLE
[Enhancement] use symbol square for translator handle

### DIFF
--- a/src/napari_threedee/_backend/manipulator/vispy_manipulator_visual.py
+++ b/src/napari_threedee/_backend/manipulator/vispy_manipulator_visual.py
@@ -97,6 +97,7 @@ class ManipulatorVisual(Compound):
             pos=self.manipulator_visual_data.translator_handle_data.points[:, ::-1],
             face_color=self.manipulator_visual_data.translator_handle_colors,
             size=self.manipulator_visual_data.translator_handle_data.handle_size,
+            symbol="square"
         )
 
     def _update_rotator_visuals(self):


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/153
This PR sets the vispy marker symbol for the translator handle to square, to set it off visually from the rotator handles. This way the color coordination is preserved, but there is still a visual difference which makes it easier to explain what does what.

Here's what RenderPlane Manipulator looks like now:
<img width="1198" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/f7f20b84-2528-4aca-971f-f691818dab45">

Note I kept the `spherical` because otherwise it looked really wierd without the 3D effect. So it looks a bit wierd, but it does stand out against the other handles.
Open to suggestions for something else. I tried a few of the other symbols and they didn't really work as well as I thought.