### PR TITLE
[Enhancement] enable all the rotators for render plane manipulator

### DIFF
--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -9,7 +9,7 @@ class RenderPlaneManipulator(BaseManipulator):
     """A manipulator for moving and orienting an image layer rendering plane."""
 
     def __init__(self, viewer, layer=None):
-        super().__init__(viewer, layer, rotator_axes='yz', translator_axes='z')
+        super().__init__(viewer, layer, rotator_axes='xyz', translator_axes='z')
 
     def set_layers(self, layers: napari.layers.Image):
         super().set_layers(layers)


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/164
When I first started using the render plane manipulator I was a bit confused as to the 2 balls.
It's a bit tricky to position the plane how you want because you need to "rotate the manipulator" and then rotate the plane -- even for simple orthogonal rotations.

Here I enable the rotators for all the axes. It's busier, but I i think it's more visually consistent and easier to understand that you can rotate around each axis. For the translator, It does benefit form https://github.com/napari-threedee/napari-threedee/pull/165
to make translator vs. rotator more clear.

Anyhow, here's what it looks like now:
<img width="1198" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/f7a4a59a-f195-45b6-9fa2-d3af4a72d765">

Just throwing this out.