### PR TITLE
fix the point manipulator

### DIFF
--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -120,6 +120,9 @@ class PointManipulator(BaseManipulator):
     def napari_selection_callback_passthrough(self, layer, event):
         if self._backend.is_dragging:  # early exit if manipulator clicked
             return
+        if layer.mode == "pan_zoom":
+            # don't change selection if in pan zoom
+            return
         # if manipulator not clicked, do normal point selection
         value = layer.get_value(
             position=event.position,

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -25,7 +25,8 @@ class PointManipulator(BaseManipulator):
     def _connect_events(self):
         if self.layer is None:
             return
-        self.layer.events.highlight.connect(self._on_selection_change)
+        # self.layer.events.highlight.connect(self._on_selection_change)
+        self.layer.selected_data.events.items_changed.connect(self._on_selection_change)
         remove_mouse_callback_safe(
             self.layer.mouse_drag_callbacks,
             napari_selection_callback
@@ -58,6 +59,7 @@ class PointManipulator(BaseManipulator):
         return self.layer.data[self.active_point_index]
 
     def _on_selection_change(self, event=None):
+        print("hi")
         # early exit cases
         if self.layer is None:
             return
@@ -67,6 +69,7 @@ class PointManipulator(BaseManipulator):
             return
 
         selected_points = list(self.layer.selected_data)
+
         if len(selected_points) == 1:
             # replace napari selection callback with n3d passthrough
             remove_mouse_callback_safe(
@@ -81,6 +84,7 @@ class PointManipulator(BaseManipulator):
 
             # update manipulator position
             self.origin = self.active_point_position
+
         else:
             # reinstate original callbacck
             self.visible = False
@@ -94,17 +98,25 @@ class PointManipulator(BaseManipulator):
                 )
 
     def _pre_drag(self):
-        self.layer.events.highlight.disconnect(self._on_selection_change)
+        # self.layer.events.highlight.disconnect(self._on_selection_change)
+        pass
 
     def _while_dragging_translator(self):
+        print("while drag start")
+        print(self._backend.vispy_visual.transform)
         selected_point_index = list(self.layer.selected_data)[0]
         self.layer.data[selected_point_index] = self.origin
-        # refresh rendering manually after modifying array data inplace
-        self.layer.refresh()
+        # # refresh rendering manually after modifying array data inplace
+        # with self.layer.events.highlight.blocker():
+        self.layer.events.set_data()
+
+        self._backend._on_transformation_changed()
+        print("after hack")
+        print(self._backend.vispy_visual.transform)
 
     def _post_drag(self):
-        self.layer.events.highlight.connect(self._on_selection_change)
-
+        # self.layer.events.highlight.connect(self._on_selection_change)
+        pass
 
     # def _while_dragging_rotator(self, selected_rotator: int, rotation_matrix: np.ndarray):
     #     # todo: store rotmat somewhere

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -25,7 +25,6 @@ class PointManipulator(BaseManipulator):
     def _connect_events(self):
         if self.layer is None:
             return
-        # self.layer.events.highlight.connect(self._on_selection_change)
         self.layer.selected_data.events.items_changed.connect(self._on_selection_change)
         remove_mouse_callback_safe(
             self.layer.mouse_drag_callbacks,
@@ -40,7 +39,7 @@ class PointManipulator(BaseManipulator):
     def _disconnect_events(self):
         if self.layer is None:
             return
-        self.layer.events.highlight.disconnect(self._on_selection_change)
+        self.layer.selected_data.events.items_changed.disconnect(self._on_selection_change)
         remove_mouse_callback_safe(
             self.layer.mouse_drag_callbacks,
             self.napari_selection_callback_passthrough
@@ -59,7 +58,6 @@ class PointManipulator(BaseManipulator):
         return self.layer.data[self.active_point_index]
 
     def _on_selection_change(self, event=None):
-        print("hi")
         # early exit cases
         if self.layer is None:
             return
@@ -98,24 +96,21 @@ class PointManipulator(BaseManipulator):
                 )
 
     def _pre_drag(self):
-        # self.layer.events.highlight.disconnect(self._on_selection_change)
         pass
 
     def _while_dragging_translator(self):
-        print("while drag start")
-        print(self._backend.vispy_visual.transform)
         selected_point_index = list(self.layer.selected_data)[0]
         self.layer.data[selected_point_index] = self.origin
         # # refresh rendering manually after modifying array data inplace
         # with self.layer.events.highlight.blocker():
         self.layer.events.set_data()
 
+        # this is a hack because the transforms were getting overwritten
+        # after the set_data() event.
+        # https://github.com/napari-threedee/napari-threedee/pull/167
         self._backend._on_transformation_changed()
-        print("after hack")
-        print(self._backend.vispy_visual.transform)
 
     def _post_drag(self):
-        # self.layer.events.highlight.connect(self._on_selection_change)
         pass
 
     # def _while_dragging_rotator(self, selected_rotator: int, rotation_matrix: np.ndarray):


### PR DESCRIPTION
The point manipulator wasn't working because the translation on the manipulator kept getting overwritten during the drag. I chased this down to this layer refresh call: https://github.com/napari-threedee/napari-threedee/blob/ba8a5af163dad60c1e42d34e1c246bdd72fcf208/src/napari_threedee/manipulators/point_manipulator.py#L103

If you replace it with a `layer.events.set_data()` call, the problem persists. That event pretty much only triggers this callback: https://github.com/napari/napari/blob/cf68ee5ffbe6f5ff4861642c759eaff181ef6749/napari/_vispy/layers/points.py#L42-L88

so I think it's something in there (e.g., the `self.reset()`). I think this is caused by the manipulator visual being a child of the layer visual. This might indicate that we want to separate the manipulator and layer visuals.