### PR TITLE
make manipulators use world coordinates

### DIFF
--- a/src/napari_threedee/_backend/manipulator/drag_managers.py
+++ b/src/napari_threedee/_backend/manipulator/drag_managers.py
@@ -1,4 +1,5 @@
 import napari
+from napari.layers.utils.interactivity_utils import drag_data_to_projected_distance
 from napari.utils.geometry import intersect_line_with_plane_3d
 import numpy as np
 
@@ -81,12 +82,18 @@ class TranslatorDragManager:
         self._view_direction = mouse_event.view_direction
 
     def update_drag(self, mouse_event):
-        projected_distance = self._layer.projected_distance_from_mouse_drag(
+        # projected_distance = self._layer.projected_distance_from_mouse_drag(
+        #     start_position=self._initial_position_world,
+        #     end_position=mouse_event.position,
+        #     view_direction=mouse_event.view_direction,
+        #     vector=self.translation_vector,
+        #     dims_displayed=mouse_event.dims_displayed
+        # )
+        projected_distance = drag_data_to_projected_distance(
             start_position=self._initial_position_world,
             end_position=mouse_event.position,
             view_direction=mouse_event.view_direction,
-            vector=self.translation_vector,
-            dims_displayed=mouse_event.dims_displayed
+            vector=self.translation_vector
         )
         translator_drag_vector = projected_distance * self.translation_vector
         updated_translation = self._initial_translation + translator_drag_vector

--- a/src/napari_threedee/_backend/manipulator/drag_managers.py
+++ b/src/napari_threedee/_backend/manipulator/drag_managers.py
@@ -22,11 +22,15 @@ class RotatorDragManager:
                    rotation_matrix=np.ndarray):
         self._layer = layer
 
-        click_point_data, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(layer,
-                                                                                                     mouse_event)
+        # click_point_data, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(layer,
+        #                                                                                              mouse_event)
+
+        # todo make 3D only
+        click_position_3d = mouse_event.position
+        click_direction_3d = mouse_event.view_direction
         click_on_rotation_plane = intersect_line_with_plane_3d(
-            line_position=click_point_data,
-            line_direction=click_dir_data_3d,
+            line_position=click_position_3d,
+            line_direction=click_direction_3d,
             plane_position=translation,
             plane_normal=self.rotation_vector,
         )
@@ -34,11 +38,10 @@ class RotatorDragManager:
         self._initial_click_vector = np.squeeze(click_on_rotation_plane) - translation
         self._initial_rotation_matrix = rotation_matrix.copy()
         self._initial_translation = translation
-        self._view_direction = click_dir_data_3d
+        self._view_direction = click_direction_3d
 
     def update_drag(self, mouse_event):
-        click_point_data = np.asarray(self._layer.world_to_data(mouse_event.position))[
-            mouse_event.dims_displayed]
+        click_point_data = np.asarray(mouse_event.position)[mouse_event.dims_displayed]
         click_on_rotation_plane = intersect_line_with_plane_3d(
             line_position=click_point_data,
             line_direction=self._view_direction,
@@ -70,12 +73,12 @@ class TranslatorDragManager:
                    rotation_matrix=np.ndarray):
         self._layer = layer
 
-        _, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(layer, mouse_event)
+        # _, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(layer, mouse_event)
 
         self._initial_position_world = mouse_event.position
         self._initial_rotation_matrix = np.copy(rotation_matrix)
         self._initial_translation = np.copy(translation)
-        self._view_direction = click_dir_data_3d
+        self._view_direction = mouse_event.view_direction
 
     def update_drag(self, mouse_event):
         projected_distance = self._layer.projected_distance_from_mouse_drag(

--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -11,7 +11,7 @@ from .vispy_visual_data import ManipulatorVisualData
 from .vispy_manipulator_visual import ManipulatorVisual
 from napari_threedee._backend.manipulator.drag_managers import RotatorDragManager, \
     TranslatorDragManager
-from ...utils.napari_utils import get_vispy_node, \
+from ...utils.napari_utils import get_vispy_root_node, \
     get_mouse_position_in_displayed_layer_data_coordinates, \
     add_mouse_callback_safe, remove_mouse_callback_safe
 from ...utils.selection_utils import select_sphere_from_click
@@ -65,7 +65,7 @@ class NapariManipulatorBackend:
         self._is_dragging = value
 
     def _connect_vispy_visual(self):
-        parent = get_vispy_node(self._viewer, self.layer)
+        parent = get_vispy_root_node(self._viewer, self.layer)
         self.vispy_visual.parent = parent
         self.vispy_visual.transform = MatrixTransform()
         self.vispy_visual.canvas._backend.destroyed.connect(self._set_canvas_none)

--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -97,10 +97,10 @@ class NapariManipulatorBackend:
     def _mouse_callback(self, layer, event):
         """Mouse call back for selecting and dragging a manipulator."""
         initial_layer_interactive = layer.mouse_pan
-        click_position_data_3d, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(
-            layer, event
-        )
-        drag_manager = self._drag_manager_from_click(click_position_data_3d, click_dir_data_3d)
+        # click_position_data_3d, click_dir_data_3d = get_mouse_position_in_displayed_layer_data_coordinates(
+        #     layer, event
+        # )
+        drag_manager = self._drag_manager_from_click(event.position, event.view_direction,)
         if drag_manager is None:  # no translator/rotator was clicked
             return
 

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -189,6 +189,9 @@ class BaseManipulator(N3dComponent, ABC):
     def visible(self, value: bool):
         self._backend.vispy_visual.visible = value
 
+    def _toggle_visibility(self):
+        self.visible = not self.visible
+
     @property
     def enabled(self) -> bool:
         return self._enabled
@@ -214,6 +217,10 @@ class BaseManipulator(N3dComponent, ABC):
                 self.layer.mouse_drag_callbacks,
                 self._mouse_callback
             )
+
+    def _disable_and_remove(self):
+        self.enabled = False
+        self._backend.vispy_visual.parent.children.remove(self._backend.vispy_visual)
 
     def _on_ndisplay_change(self, event=None):
         if self._viewer.dims.ndisplay == 2:

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -189,8 +189,8 @@ class BaseManipulator(N3dComponent, ABC):
     def visible(self, value: bool):
         self._backend.vispy_visual.visible = value
 
-    def _toggle_visibility(self):
-        self.visible = not self.visible
+    def _on_visibility_change(self):
+        self.visible = self.layer.visible
 
     @property
     def enabled(self) -> bool:

--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -19,17 +19,10 @@ class LayerManipulator(BaseManipulator):
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _initialize_transform(self):
-        # self.origin = self.layer.translate[self.layer._dims_displayed]
-        self.origin = np.asarray((0, 0, 0))
+        self.origin = np.asarray(self.layer.translate)
 
     def _pre_drag(self):
-        dims_displayed = get_dims_displayed(self.layer)
-        self.translate_start = self.layer.translate[dims_displayed].copy()
+        self.translate_start = self.origin.copy()
 
     def _while_dragging_translator(self):
-        new_translate = self.translate_start + self.origin
-        self.layer.translate = new_translate
-        # origin is relative to the layer transform so needs
-        # to be reset after updating the transform
-        self.origin = np.asarray((0, 0, 0))
-
+        self.layer.translate = self.origin

--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -15,7 +15,7 @@ class LayerManipulator(BaseManipulator):
         super().set_layers(layer)
 
     def _connect_events(self):
-        self.layer.events.visible.connect(self._toggle_visibility)
+        self.layer.events.visible.connect(self._on_visibility_change)
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _initialize_transform(self):

--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -14,6 +14,10 @@ class LayerManipulator(BaseManipulator):
     def set_layers(self, layer: napari.layers.Layer):
         super().set_layers(layer)
 
+    def _connect_events(self):
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
+
     def _initialize_transform(self):
         # self.origin = self.layer.translate[self.layer._dims_displayed]
         self.origin = np.asarray((0, 0, 0))

--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -19,7 +19,8 @@ class LayerManipulator(BaseManipulator):
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _initialize_transform(self):
-        self.origin = np.asarray(self.layer.translate)
+        self.origin = np.asarray(self.layer.data_to_world((0, 0, 0)))
+        print(self.origin)
 
     def _pre_drag(self):
         self.translate_start = self.origin.copy()

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -36,7 +36,7 @@ class PointManipulator(BaseManipulator):
                 self.layer.mouse_drag_callbacks,
                 self.napari_selection_callback_passthrough
             )
-        self.layer.events.visible.connect(self._toggle_visibility)
+        self.layer.events.visible.connect(self._on_visibility_change)
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -36,6 +36,8 @@ class PointManipulator(BaseManipulator):
                 self.layer.mouse_drag_callbacks,
                 self.napari_selection_callback_passthrough
             )
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):
         if self.layer is None:

--- a/src/napari_threedee/manipulators/point_manipulator.py
+++ b/src/napari_threedee/manipulators/point_manipulator.py
@@ -1,4 +1,5 @@
 import napari
+import numpy as np
 from napari.layers.points._points_mouse_bindings import select as napari_selection_callback
 from napari.layers.points._points_constants import Mode
 
@@ -54,8 +55,10 @@ class PointManipulator(BaseManipulator):
         return list(self.layer.selected_data)[0]
 
     @property
-    def active_point_position(self):
-        return self.layer.data[self.active_point_index]
+    def active_point_position(self) -> np.ndarray:
+        """Get the active point position in world coordinates."""
+        position_layer_coordinates = self.layer.data[self.active_point_index]
+        return np.asarray(self.layer.data_to_world(position_layer_coordinates))
 
     def _on_selection_change(self, event=None):
         # early exit cases
@@ -99,8 +102,13 @@ class PointManipulator(BaseManipulator):
         pass
 
     def _while_dragging_translator(self):
-        selected_point_index = list(self.layer.selected_data)[0]
-        self.layer.data[selected_point_index] = self.origin
+        selected_data = list(self.layer.selected_data)
+        if len(selected_data) == 0:
+            # return early if no data
+            return
+        selected_point_index = selected_data[0]
+        position_layer_coordinates = self.layer.world_to_data(self.origin)
+        self.layer.data[selected_point_index] = position_layer_coordinates
         # # refresh rendering manually after modifying array data inplace
         # with self.layer.events.highlight.blocker():
         self.layer.events.set_data()

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -18,6 +18,8 @@ class RenderPlaneManipulator(BaseManipulator):
     def _connect_events(self):
         self.layer.plane.events.position.connect(self._update_transform)
         self.layer.plane.events.normal.connect(self._update_transform)
+        self.layer.events.visible.connect(self._toggle_visibility)
+        self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):
         self.layer.plane.events.position.disconnect(self._update_transform)

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -35,7 +35,7 @@ class RenderPlaneManipulator(BaseManipulator):
         self.origin = np.array(origin_world)
         plane_normal_data = self.layer.plane.normal
         plane_normal_world = data_to_world_ray(vector=plane_normal_data, layer=self.layer)
-        self.rotation_matrix = rotation_matrix_from_vectors_3d([1, 0, 0], plane_normal_data)
+        self.rotation_matrix = rotation_matrix_from_vectors_3d([1, 0, 0], plane_normal_world)
 
     def _while_dragging_translator(self):
         with self.layer.plane.events.position.blocker(self._update_transform):

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -18,7 +18,7 @@ class RenderPlaneManipulator(BaseManipulator):
     def _connect_events(self):
         self.layer.plane.events.position.connect(self._update_transform)
         self.layer.plane.events.normal.connect(self._update_transform)
-        self.layer.events.visible.connect(self._toggle_visibility)
+        self.layer.events.visible.connect(self._on_visibility_change)
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -3,7 +3,7 @@ from napari.utils.events.event import EventBlocker
 from napari.utils.geometry import rotation_matrix_from_vectors_3d
 import numpy as np
 from napari_threedee.manipulators.base_manipulator import BaseManipulator
-from napari_threedee.utils.napari_utils import data_to_world_ray
+from napari_threedee.utils.napari_utils import data_to_world_normal, world_to_data_normal
 
 
 class RenderPlaneManipulator(BaseManipulator):
@@ -36,7 +36,7 @@ class RenderPlaneManipulator(BaseManipulator):
         origin_world = self.layer.data_to_world(self.layer.plane.position)
         self.origin = np.array(origin_world)
         plane_normal_data = self.layer.plane.normal
-        plane_normal_world = data_to_world_ray(vector=plane_normal_data, layer=self.layer)
+        plane_normal_world = data_to_world_normal(vector=plane_normal_data, layer=self.layer)
         self.rotation_matrix = rotation_matrix_from_vectors_3d([1, 0, 0], plane_normal_world)
 
     def _while_dragging_translator(self):
@@ -45,8 +45,5 @@ class RenderPlaneManipulator(BaseManipulator):
 
     def _while_dragging_rotator(self):
         with self.layer.plane.events.normal.blocker(self._update_transform):
-            z_vector_data = self.layer._world_to_data_ray(self.z_vector)
-            self.layer.plane.normal = self.z_vector
-
-            print(self.z_vector, z_vector_data)
-
+            z_vector_data = world_to_data_normal(vector=self.z_vector, layer=self.layer)
+            self.layer.plane.normal = z_vector_data

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -169,7 +169,7 @@ def data_to_world_ray(vector, layer):
     Parameters
     ----------
     vector : tuple, list, 1D array
-        A vector in world coordinates.
+        A vector in data coordinates.
     layer : napari.layers.BaseLayer
         The napari layer to get the transform from.
 
@@ -194,7 +194,7 @@ def data_to_world_normal(vector, layer):
     Parameters
     ----------
     vector : tuple, list, 1D array
-        A vector in world coordinates.
+        A vector in data coordinates.
     layer : napari.layers.BaseLayer
         The napari layer to get the transform from.
 
@@ -207,6 +207,38 @@ def data_to_world_normal(vector, layer):
 
     # get the transform
     inverse_transform = layer._transforms[1:].simplified.inverse.linear_matrix
+    transpose_inverse_transform = inverse_transform.T
+
+    # transform the vector
+    transformed_vector = np.matmul(transpose_inverse_transform, unit_vector)
+
+    return transformed_vector / np.linalg.norm(transformed_vector)
+
+
+def world_to_data_normal(vector, layer):
+    """Convert a normal vector defining an orientation from world coordinates to data coordinates.
+    For example, this would be used to a plane normal.
+
+    https://www.scratchapixel.com/lessons/mathematics-physics-for-computer-graphics/geometry/transforming-normals.html
+
+    Parameters
+    ----------
+    vector : tuple, list, 1D array
+        A vector in world coordinates.
+    layer : napari.layers.BaseLayer
+        The napari layer to get the transform from.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed vector in data coordinates. This returns a unit vector.
+    """
+    unit_vector = np.asarray(vector) / np.linalg.norm(vector)
+
+    # get the transform
+    # the napari transform is from layer -> world.
+    # We want the inverse of the world ->  layer, so we just take the napari transform
+    inverse_transform = layer._transforms[1:].simplified.linear_matrix
     transpose_inverse_transform = inverse_transform.T
 
     # transform the vector

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -163,19 +163,20 @@ def get_mouse_position_in_displayed_layer_data_coordinates(layer, event) -> Tupl
 
 
 def data_to_world_ray(vector, layer):
-
-    """Convert a vector defining an orientation from world coordinates to data coordinates.
+    """Convert a vector defining an orientation from data coordinates to world coordinates.
     For example, this would be used to convert the view ray.
 
     Parameters
     ----------
     vector : tuple, list, 1D array
         A vector in world coordinates.
+    layer : napari.layers.BaseLayer
+        The napari layer to get the transform from.
 
     Returns
     -------
-    tuple : np.ndarray
-        Vector in data coordinates.
+    np.ndarray
+        Transformed vector in data coordinates.
     """
     p1 = np.asarray(layer.data_to_world(vector))
     p0 = np.asarray(layer.data_to_world(np.zeros_like(vector)))
@@ -183,3 +184,32 @@ def data_to_world_ray(vector, layer):
 
     return normalized_vector
 
+
+def data_to_world_normal(vector, layer):
+    """Convert a normal vector defining an orientation from data coordinates to world coordinates.
+    For example, this would be used to a plane normal.
+
+    https://www.scratchapixel.com/lessons/mathematics-physics-for-computer-graphics/geometry/transforming-normals.html
+
+    Parameters
+    ----------
+    vector : tuple, list, 1D array
+        A vector in world coordinates.
+    layer : napari.layers.BaseLayer
+        The napari layer to get the transform from.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed vector in data coordinates. This returns a unit vector.
+    """
+    unit_vector = np.asarray(vector) / np.linalg.norm(vector)
+
+    # get the transform
+    inverse_transform = layer._transforms[1:].simplified.inverse.linear_matrix
+    transpose_inverse_transform = inverse_transform.T
+
+    # transform the vector
+    transformed_vector = np.matmul(transpose_inverse_transform, unit_vector)
+
+    return transformed_vector / np.linalg.norm(transformed_vector)

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -162,3 +162,24 @@ def get_mouse_position_in_displayed_layer_data_coordinates(layer, event) -> Tupl
     return click_position_data_3d, click_dir_data_3d
 
 
+def data_to_world_ray(vector, layer):
+
+    """Convert a vector defining an orientation from world coordinates to data coordinates.
+    For example, this would be used to convert the view ray.
+
+    Parameters
+    ----------
+    vector : tuple, list, 1D array
+        A vector in world coordinates.
+
+    Returns
+    -------
+    tuple : np.ndarray
+        Vector in data coordinates.
+    """
+    p1 = np.asarray(layer.data_to_world(vector))
+    p0 = np.asarray(layer.data_to_world(np.zeros_like(vector)))
+    normalized_vector = (p1 - p0) / np.linalg.norm(p1 - p0)
+
+    return normalized_vector
+

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -40,14 +40,25 @@ def get_napari_visual(viewer, layer):
     return visual
 
 
-def get_vispy_node(viewer, layer):
-    """"""
+def get_vispy_layer_node(viewer: napari.Viewer, layer):
+    """Get the vispy node associated with a layer"""
     napari_visual = get_napari_visual(viewer, layer)
 
     if isinstance(layer, Image):
         return napari_visual._layer_node.get_node(3)
     elif isinstance(layer, Points):
         return napari_visual.node
+
+
+def get_vispy_root_node(viewer: napari.Viewer, layer):
+    """Get the vispy node at the root of the scene graph.
+
+    This is the node that layers are added to.
+    """
+    # this will need to be updated in napari 0.5.0
+    viewer.window._qt_window._qt_viewer.canvas.view.scene
+    qt_viewer = viewer.window._qt_window._qt_viewer
+    return qt_viewer.view.scene
 
 
 def remove_mouse_callback_safe(callback_list, callback):

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -56,7 +56,7 @@ def get_vispy_root_node(viewer: napari.Viewer, layer):
     This is the node that layers are added to.
     """
     # this will need to be updated in napari 0.5.0
-    viewer.window._qt_window._qt_viewer.canvas.view.scene
+    # viewer.window._qt_window._qt_viewer.canvas.view.scene
     qt_viewer = viewer.window._qt_window._qt_viewer
     return qt_viewer.view.scene
 


### PR DESCRIPTION
As discussed in #163 , switching the manipulators to world coordinates may be beneficial for keeping the size correct when the layers have scale.

The current approach:
- add the manipulator visual to the root of the scene https://github.com/napari-threedee/napari-threedee/pull/168/commits/f09616f9636b4a343929fa76b559cdb2d28f08e0
- make the base manipulator use world coordinates: https://github.com/napari-threedee/napari-threedee/pull/168/commits/03b791724a4c0345a50314bec9d3b0863d75619f
- update the point manipulator to use world coordinates: https://github.com/napari-threedee/napari-threedee/pull/168/commits/3d54cadfe546f7bf3b95e34048f0eb7207cfc5b3
- update the render plane manipulator to use world coordinates. needed to add util functions for transforming the normal vector: https://github.com/napari-threedee/napari-threedee/pull/168#issuecomment-2049333677
- make layer manipulator use world coordinates: https://github.com/napari-threedee/napari-threedee/pull/168/commits/20b7aaca9c0cdcce1bb4841630b5e0d39c716768 https://github.com/napari-threedee/napari-threedee/pull/168/commits/835ccff9e61dcbcbed524e4f8e4be39c87fd2df5