### PR TITLE
Enhancement: add radius and handle_size as a properties of base_manipulator

### DIFF
--- a/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
+++ b/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
@@ -71,3 +71,41 @@ def test_ndisplay_change(viewer_with_plane_3d):
 
     viewer.dims.ndisplay = 2
     assert manipulator.enabled is False
+
+def test_radius_setter(viewer_with_plane_3d):
+    """Test that the radius setter affects the components as expected."""
+    viewer = viewer_with_plane_3d
+    manipulator = RenderPlaneManipulator(viewer=viewer, layer=viewer.layers[0])
+
+    assert manipulator.radius == 20
+    for translator in manipulator._backend.manipulator_model.translators:
+        assert translator.distance_from_origin == 20
+    for rotator in manipulator._backend.manipulator_model.rotators:
+        assert rotator.distance_from_origin == 20
+    for axis in manipulator._backend.manipulator_model.central_axes:
+        assert axis.length == 20
+
+    manipulator.radius = 50
+    for translator in manipulator._backend.manipulator_model.translators:
+        assert translator.distance_from_origin == 50
+    for rotator in manipulator._backend.manipulator_model.rotators:
+        assert rotator.distance_from_origin == 50
+    for axis in manipulator._backend.manipulator_model.central_axes:
+        assert axis.length == 50
+
+def test_handle_size_setter(viewer_with_plane_3d):
+    """Test that the handle_size setter affects the components as expected."""
+    viewer = viewer_with_plane_3d
+    manipulator = RenderPlaneManipulator(viewer=viewer, layer=viewer.layers[0])
+
+    assert manipulator.handle_size == 10
+    for translator in manipulator._backend.manipulator_model.translators:
+        assert translator.handle_size == 10
+    for rotator in manipulator._backend.manipulator_model.rotators:
+        assert rotator.handle_size == 10
+
+    manipulator.handle_size = 20
+    for translator in manipulator._backend.manipulator_model.translators:
+        assert translator.handle_size == 20
+    for rotator in manipulator._backend.manipulator_model.rotators:
+        assert rotator.handle_size == 20

--- a/src/napari_threedee/_backend/manipulator/rotator.py
+++ b/src/napari_threedee/_backend/manipulator/rotator.py
@@ -10,6 +10,7 @@ from .axis_model import AxisSet, AxisModel
 class Rotator(BaseModel, _Grabbable):
     axis: AxisModel
     distance_from_origin: float = 20
+    handle_size: float = 10
 
     @property
     def handle_point(self):

--- a/src/napari_threedee/_backend/manipulator/translator.py
+++ b/src/napari_threedee/_backend/manipulator/translator.py
@@ -10,10 +10,14 @@ from napari_threedee._backend.manipulator.axis_model import AxisSet, AxisModel
 class Translator(BaseModel, _Grabbable):
     """Axis, offset from origin with a handle at the base."""
     axis: AxisModel
-    length: float = 3
     distance_from_origin: float = 20  # distance of start point from origin
     handle_size: float = 10
 
+    @property
+    def length(self) -> np.ndarray:
+        """length of the extra segment beyond the radius"""
+        return np.floor(self.distance_from_origin/7)+1
+        
     @property
     def start_point(self) -> np.ndarray:
         return self.distance_from_origin * np.array(self.axis.vector)

--- a/src/napari_threedee/_backend/manipulator/translator.py
+++ b/src/napari_threedee/_backend/manipulator/translator.py
@@ -12,6 +12,7 @@ class Translator(BaseModel, _Grabbable):
     axis: AxisModel
     length: float = 3
     distance_from_origin: float = 21  # distance of start point from origin
+    handle_size: float = 10
 
     @property
     def start_point(self) -> np.ndarray:

--- a/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
+++ b/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
@@ -107,9 +107,8 @@ class ManipulatorHandleData(BaseModel):
     """Data required to construct a VisPy points visuals and relate points to axes."""
     points: np.ndarray  # (n_handles, 3) array of points
     colors: np.ndarray  # (n_handles, 4) array of RGBA colors for points
+    handle_size: np.ndarray  # (n_handles, ) array of handle sizes
     axis_identifiers: np.ndarray  # (n_points, ) array of axis identifiers
-
-    handle_size: float = 10
 
     class Config:
         arbitrary_types_allowed = True
@@ -119,6 +118,7 @@ class ManipulatorHandleData(BaseModel):
         return cls(
             points=translator.start_point.reshape((1, 3)),
             colors=translator.axis.color.reshape((1, 4)),
+            handle_size=np.array([translator.handle_size]),
             axis_identifiers=np.array([translator.axis.id])
         )
 
@@ -131,6 +131,7 @@ class ManipulatorHandleData(BaseModel):
         return cls(
             points=rotator.handle_point.reshape((1, 3)),
             colors=rotator.axis.color.reshape((1, 4)),
+            handle_size=np.array([rotator.handle_size]),
             axis_identifiers=np.array([rotator.axis.id])
         )
 
@@ -146,8 +147,9 @@ class ManipulatorHandleData(BaseModel):
             return self
         points = np.concatenate([self.points, other.points], axis=0)
         colors = np.concatenate([self.colors, other.colors], axis=0)
+        handle_size = np.concatenate([self.handle_size, other.handle_size], axis=0)
         axis_ids = np.concatenate([self.axis_identifiers, other.axis_identifiers], axis=0)
-        return ManipulatorHandleData(points=points, colors=colors, axis_identifiers=axis_ids)
+        return ManipulatorHandleData(points=points, colors=colors, handle_size=handle_size, axis_identifiers=axis_ids)
 
     def __len__(self):
         return len(self.points)

--- a/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
+++ b/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
@@ -202,6 +202,23 @@ class ManipulatorVisualData(ModelWithSettableProperties):
             rotator_handle_data=rotator_handle_data
         )
 
+    def update_from_manipulator(self, manipulator: ManipulatorModel):
+        self.central_axis_line_data = ManipulatorLineData.from_central_axis_set(manipulator.central_axes)
+        # translators
+        if manipulator.translators is None:
+            self.translator_line_data = None
+            self.translator_handle_data = None
+        else:
+            self.translator_line_data = ManipulatorLineData.from_translator_set(manipulator.translators)
+            self.translator_handle_data = ManipulatorHandleData.from_translator_set(manipulator.translators)
+        # rotators
+        if manipulator.rotators is None:
+            self.rotator_line_data = None
+            self.rotator_handle_data = None
+        else:
+            self.rotator_line_data = ManipulatorLineData.from_rotator_set(manipulator.rotators)
+            self.rotator_handle_data = ManipulatorHandleData.from_rotator_set(manipulator.rotators)
+
     @property
     def central_axis_line_colors(self) -> np.ndarray:
         """Central axis line vertex colors, non-selected axes are attenuated."""

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -98,7 +98,6 @@ class BaseManipulator(N3dComponent, ABC):
                 axis.length = radius
 
         # update the visual data
-        # note: need to add the update_from_manipulator method
         self._backend.vispy_visual_data.update_from_manipulator(model)
 
         # trigger a redraw

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -127,7 +127,6 @@ class BaseManipulator(N3dComponent, ABC):
                 rotator.handle_size = handle_size
 
         # update the visual data
-        # note: need to add the update_from_manipulator method
         self._backend.vispy_visual_data.update_from_manipulator(model)
 
         # trigger a redraw

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -52,7 +52,9 @@ class BaseManipulator(N3dComponent, ABC):
             viewer=self._viewer,
             layer=layer,
         )
-
+        self._radius = 20
+        self._handle_size = 10
+        
         self.visible = False
         self.layer = layer
         if self.enabled:
@@ -72,12 +74,13 @@ class BaseManipulator(N3dComponent, ABC):
     def radius(self) -> float:
         """The radius of the manipulator components.
         """
-        return self._backend.manipulator_model.radius
+        return self._radius
     
     @radius.setter
     def radius(self, radius: float):
         """The radius of the manipulator components.
         """
+        self._radius = radius
         model = self._backend.manipulator_model
 
         # set the translators
@@ -105,12 +108,13 @@ class BaseManipulator(N3dComponent, ABC):
     def handle_size(self) -> float:
         """The radius of the manipulator handles.
         """
-        return self._backend.manipulator_model.handle_size
+        return self._handle_size
     
     @handle_size.setter
     def handle_size(self, handle_size: float):
         """The radius of the manipulator handles.
         """
+        self._handle_size = handle_size
         model = self._backend.manipulator_model
 
         # set the translators

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -52,6 +52,7 @@ class BaseManipulator(N3dComponent, ABC):
             viewer=self._viewer,
             layer=layer,
         )
+
         self.visible = False
         self.layer = layer
         if self.enabled:
@@ -66,6 +67,39 @@ class BaseManipulator(N3dComponent, ABC):
     def origin(self, value: np.ndarray):
         self._backend.manipulator_model.origin = value
 
+    @property
+    def radius(self) -> float:
+        """The radius of the manipulator components.
+        """
+        return self._backend.manipulator_model.radius
+    
+    @radius.setter
+    def radius(self, radius: float):
+        """The radius of the manipulator components.
+        """
+        model = self._backend.manipulator_model
+
+        # set the translators
+        if model.translators is not None:
+            for translator in model.translators:
+                translator.distance_from_origin = radius
+
+        # set the rotators
+        if model.rotators is not None:
+            for rotator in model.rotators:
+                rotator.distance_from_origin = radius
+        # set the central axis
+        if model.central_axes is not None:
+            for axis in model.central_axes:
+                axis.length = radius
+
+        # update the visual data
+        # note: need to add the update_from_manipulator method
+        self._backend.vispy_visual_data.update_from_manipulator(model)
+
+        # trigger a redraw
+        self._backend.vispy_visual.update_visuals_from_manipulator_visual_data()
+    
     @property
     def rotation_matrix(self) -> np.ndarray:
         """(3, 3) array containing the rotation matrix of the manipulator."""

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -99,6 +99,36 @@ class BaseManipulator(N3dComponent, ABC):
 
         # trigger a redraw
         self._backend.vispy_visual.update_visuals_from_manipulator_visual_data()
+
+    @property
+    def handle_size(self) -> float:
+        """The radius of the manipulator handles.
+        """
+        return self._backend.manipulator_model.handle_size
+    
+    @handle_size.setter
+    def handle_size(self, handle_size: float):
+        """The radius of the manipulator handles.
+        """
+        model = self._backend.manipulator_model
+
+        # set the translators
+        if model.translators is not None:
+            for translator in model.translators:
+                translator.handle_size = handle_size
+
+        # set the rotators
+        if model.rotators is not None:
+            for rotator in model.rotators:
+                rotator.handle_size = handle_size
+
+        # update the visual data
+        # note: need to add the update_from_manipulator method
+        self._backend.vispy_visual_data.update_from_manipulator(model)
+
+        # trigger a redraw
+        self._backend.vispy_visual.update_visuals_from_manipulator_visual_data()
+
     
     @property
     def rotation_matrix(self) -> np.ndarray:


### PR DESCRIPTION
This is based off of Kevin's thoughts here: https://github.com/napari-threedee/napari-threedee/issues/163#issuecomment-2053562968

I implemented the radius property to control the size of the manipulator.
Then in analogous fashion added handle_size.

Now I'm not sure about the latter -- I guess the handle sizes are vispy marker sizes which are in screen/scene space? so not affected by scale? Maybe unneeded, but still sometimes can be handy.

Note: right now it's just properties and setter, not in the widgets. I'd like to be sure this is working properly and then do widgets in a followup PR?
