### PR TITLE
Bugfix: update transformations on_enable

### DIFF
--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -204,6 +204,7 @@ class BaseManipulator(N3dComponent, ABC):
     def _on_enable(self):
         if self.layer is not None:
             self.visible = True
+            self._backend._on_transformation_changed()
             add_mouse_callback_safe(
                 callback_list=self.layer.mouse_drag_callbacks,
                 callback=self._mouse_callback,


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/175

I think this is the correct fix? calling the `_on_transformation_changed()` method `_on_enable`?
