### PR TITLE
[UX] flip the render plane manipulator normal

### DIFF
--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -37,7 +37,9 @@ class RenderPlaneManipulator(BaseManipulator):
         self.origin = np.array(origin_world)
         plane_normal_data = self.layer.plane.normal
         plane_normal_world = data_to_world_normal(vector=plane_normal_data, layer=self.layer)
-        self.rotation_matrix = rotation_matrix_from_vectors_3d([1, 0, 0], plane_normal_world)
+        manipulator_normal = -1 * plane_normal_world
+        self.rotation_matrix = rotation_matrix_from_vectors_3d([1, 0, 0], manipulator_normal)
+
 
     def _while_dragging_translator(self):
         with self.layer.plane.events.position.blocker(self._update_transform):


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/177

In this PR I flip the normal for the render plane manipulator.

If you use the script from the issue, you just need to tilt the camera down a smidge to be able to use the manipulator in an intuitive fashion:
<img width="1190" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/60525522-cbbc-4c57-989d-802678e12823">
