### PR TITLE
Refactor and glitch fix: drop translator_line_data and everything related

### DIFF
--- a/src/napari_threedee/_backend/manipulator/_tests/test_manipulator_visual_data.py
+++ b/src/napari_threedee/_backend/manipulator/_tests/test_manipulator_visual_data.py
@@ -47,28 +47,6 @@ def test_linedata_from_rotator_set():
     assert ld.axis_identifiers.shape == (n_expected_vertices,)
 
 
-def test_linedata_from_translator():
-    ld = ManipulatorLineData.from_translator(Translator.from_string('x'))
-    assert isinstance(ld, ManipulatorLineData)
-    n_expected_vertices = 2
-    n_expected_connections = 1
-    assert ld.vertices.shape == (n_expected_vertices, 3)
-    assert ld.connections.shape == (n_expected_connections, 2)
-    assert ld.colors.shape == (n_expected_vertices, 4)
-    assert ld.axis_identifiers.shape == (n_expected_vertices,)
-
-
-def test_linedata_from_translator_set():
-    n_translators = 3
-    ld = ManipulatorLineData.from_translator_set(TranslatorSet.from_string('xyz'))
-    assert isinstance(ld, ManipulatorLineData)
-    n_expected_vertices = 2 * n_translators
-    n_expected_connections = n_translators
-    assert ld.vertices.shape == (n_expected_vertices, 3)
-    assert ld.connections.shape == (n_expected_connections, 2)
-    assert ld.colors.shape == (n_expected_vertices, 4)
-    assert ld.axis_identifiers.shape == (n_expected_vertices,)
-
 
 def test_reindex_on_add_linedata():
     """connections must be reindexed after adding pieces of linedata together"""

--- a/src/napari_threedee/_backend/manipulator/_tests/test_manipulator_visual_data.py
+++ b/src/napari_threedee/_backend/manipulator/_tests/test_manipulator_visual_data.py
@@ -108,5 +108,4 @@ def test_manipulator_visual_data_from_manipulator():
     manipulator = ManipulatorModel(central_axes='xyz', translators='xyz', rotators='xyz')
     mvd = ManipulatorVisualData.from_manipulator(manipulator=manipulator)
     assert isinstance(mvd, ManipulatorVisualData)
-    assert isinstance(mvd.translator_line_data, ManipulatorLineData)
     assert isinstance(mvd.translator_handle_data, ManipulatorHandleData)

--- a/src/napari_threedee/_backend/manipulator/translator.py
+++ b/src/napari_threedee/_backend/manipulator/translator.py
@@ -10,24 +10,11 @@ from napari_threedee._backend.manipulator.axis_model import AxisSet, AxisModel
 class Translator(BaseModel, _Grabbable):
     """Axis, offset from origin with a handle at the base."""
     axis: AxisModel
-    length: float = 3
-    distance_from_origin: float = 21  # distance of start point from origin
-
-    @property
-    def start_point(self) -> np.ndarray:
-        return self.distance_from_origin * np.array(self.axis.vector)
-
-    @property
-    def end_point(self) -> np.ndarray:
-        return (self.distance_from_origin + self.length) * np.array(self.axis.vector)
-
-    @property
-    def points(self) -> np.ndarray:
-        return np.stack([self.start_point, self.end_point], axis=0)
+    distance_from_origin: float = 20  # distance of start point from origin
 
     @property
     def handle_point(self) -> np.ndarray:
-        return self.start_point
+        return self.distance_from_origin * np.array(self.axis.vector)
 
     @classmethod
     def from_string(cls, axis: str):

--- a/src/napari_threedee/_backend/manipulator/vispy_manipulator_visual.py
+++ b/src/napari_threedee/_backend/manipulator/vispy_manipulator_visual.py
@@ -10,7 +10,7 @@ class ManipulatorVisual(Compound):
     _line_antialiasing_width: float = 2
 
     def __init__(self, parent, manipulator_visual_data: ManipulatorVisualData):
-        super().__init__([Line(), Line(), Markers(), Markers(), Line(), Markers()], parent=parent)
+        super().__init__([Line(), Line(), Markers(), Markers(), Markers()], parent=parent)
         self.unfreeze()
         self._manipulator_visual_data = manipulator_visual_data
         self.freeze()
@@ -35,7 +35,6 @@ class ManipulatorVisual(Compound):
         self.translator_handle_visual.spherical = True
         self.translator_handle_visual.scaling = True
         self.translator_handle_visual.antialias = self._line_antialiasing_width
-        self.translator_line_visual.antialias = self._line_antialiasing_width
 
     @classmethod
     def from_manipulator(cls, manipulator: ManipulatorModel):
@@ -63,12 +62,8 @@ class ManipulatorVisual(Compound):
         return self._subvisuals[2]
 
     @property
-    def translator_line_visual(self) -> Line:
-        return self._subvisuals[4]
-
-    @property
     def translator_handle_visual(self) -> Markers:
-        return self._subvisuals[5]
+        return self._subvisuals[4]
 
     def update_visuals_from_manipulator_visual_data(self):
         self._update_central_axis_visual()
@@ -85,14 +80,8 @@ class ManipulatorVisual(Compound):
         )
 
     def _update_translator_visuals(self):
-        if self.manipulator_visual_data.translator_line_data is None:
+        if self.manipulator_visual_data.translator_handle_data is None:
             return
-        self.translator_line_visual.set_data(
-            pos=self.manipulator_visual_data.translator_line_data.vertices[:, ::-1],
-            connect=self.manipulator_visual_data.translator_line_data.connections,
-            color=self.manipulator_visual_data.translator_line_colors,
-            width=self.manipulator_visual_data.translator_line_data.line_width,
-        )
         self.translator_handle_visual.set_data(
             pos=self.manipulator_visual_data.translator_handle_data.points[:, ::-1],
             face_color=self.manipulator_visual_data.translator_handle_colors,


### PR DESCRIPTION
Closes: #179 

In #179 I determined that the translator_line was just the short `length=3` segment.
I think in the past that short line segment *was the handle*, but now translators have distinct handles.
The actual axis line is handled by central_axis, not the translator.

So in this PR I drop all code related to the translator_line element.
The net result is the glitch is fixed and the translator handle sits on the end of the axis.

Render plane manipulator with this change:
<img width="1190" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/3193a6f1-94ab-44cd-84f7-31db8deedd01">

Point manipulator with the change:
<img width="1190" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/2c4262eb-378e-48c5-a644-f6650694f109">

Layer manipulator with the change:
<img width="1190" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/695e60cd-043a-4eab-9707-6628a0a2e3ec">

