### PR TITLE
[Maint] test on python 3.11

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{38,39,310,311}-{linux,macos,windows}
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
     
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
(not sure why I wrote 3.12 in the commit...we'll want that sooner rather than later though too I guess)
This PR adds python 3.11 to the test matrix.
Also may want to consider dropping 3.8 soon-ish. 
napari dropped testing for 3.8 (and added 3.12) here: https://github.com/napari/napari/pull/6738