### PR TITLE
[bugfix] connect to ndisplay change and set node.order

### DIFF
--- a/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
+++ b/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from napari_threedee._backend.manipulator.manipulator_model import ManipulatorModel
+from napari_threedee.manipulators import RenderPlaneManipulator
 
 
 def test_instantiation():
@@ -46,3 +47,14 @@ def test_selected_object_type_update():
     assert manipulator.selected_object_type == 'rotator'
     manipulator.selected_axis_id = None
     assert manipulator.selected_object_type is None
+
+def test_ndisplay_change(viewer_with_plane_3d):
+    """Test the manipulator is disabled when switching to 2D display."""
+    viewer = viewer_with_plane_3d
+    manipulator = RenderPlaneManipulator(viewer=viewer, layer=viewer.layers[0])
+
+    assert viewer.dims.ndisplay == 3
+    assert manipulator.enabled
+
+    viewer.dims.ndisplay = 2
+    assert manipulator.enabled is False

--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -43,6 +43,9 @@ class NapariManipulatorBackend:
         self.vispy_visual.update()
         self.vispy_visual.update_visuals_from_manipulator_visual_data()
 
+        self._viewer.dims.events.ndisplay.connect(self._on_ndisplay_change)
+
+
     @property
     def layer(self) -> napari.layers.Layer:
         return self._layer
@@ -199,10 +202,15 @@ class NapariManipulatorBackend:
         # update transform on vispy manipulator
         self.vispy_visual.transform.matrix = affine_matrix
 
-    def _on_ndisplay_change(self, event=None):
-        if self._viewer.dims.ndisplay == 2:
+    def _on_ndisplay_change(self, event):
+        new_ndisplay = event.value
+        vispy_visual_index = self.vispy_visual.parent.children.index(self._backend.vispy_visual)
+        if new_ndisplay == 2:
+            self.vispy_visual.parent.children[vispy_visual_index].order = 0
             self._disconnect_mouse_callback()
         else:
+            # set manipulator visual to be on top of layer volume visuals
+            self.vispy_visual.parent.children[vispy_visual_index].order = 1
             self._connect_mouse_callback()
 
     def _set_canvas_none(self):

--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -204,7 +204,7 @@ class NapariManipulatorBackend:
 
     def _on_ndisplay_change(self, event):
         new_ndisplay = event.value
-        vispy_visual_index = self.vispy_visual.parent.children.index(self._backend.vispy_visual)
+        vispy_visual_index = self.vispy_visual.parent.children.index(self.vispy_visual)
         if new_ndisplay == 2:
             self.vispy_visual.parent.children[vispy_visual_index].order = 0
             self._disconnect_mouse_callback()

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -222,6 +222,8 @@ class BaseManipulator(N3dComponent, ABC):
 
     def _disable_and_remove(self):
         self.enabled = False
+        self._backend.vispy_visual.parent = None
+
 
     def _on_ndisplay_change(self, event):
         new_ndisplay = event.value

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -56,6 +56,7 @@ class BaseManipulator(N3dComponent, ABC):
         self.layer = layer
         if self.enabled:
             self._on_enable()
+        self._viewer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
     @property
     def origin(self) -> np.ndarray:
@@ -223,11 +224,15 @@ class BaseManipulator(N3dComponent, ABC):
         self.enabled = False
         self._backend.vispy_visual.parent.children.remove(self._backend.vispy_visual)
 
-    def _on_ndisplay_change(self, event=None):
-        if self._viewer.dims.ndisplay == 2:
+    def _on_ndisplay_change(self, event):
+        new_ndisplay = event.value
+        vispy_visual_index = self._backend.vispy_visual.parent.children.index(self._backend.vispy_visual)
+        if new_ndisplay == 2:
+            self._backend.vispy_visual.parent.children[vispy_visual_index].order = 0
             self.enabled = False
         else:
             self.enabled = True
+            self._backend.vispy_visual.parent.children[vispy_visual_index].order = 1
 
     def _mouse_callback(self, layer, event):
         """Update the manipulated object via subclass implementations of drag/rotate behaviour."""

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -222,17 +222,13 @@ class BaseManipulator(N3dComponent, ABC):
 
     def _disable_and_remove(self):
         self.enabled = False
-        self._backend.vispy_visual.parent.children.remove(self._backend.vispy_visual)
 
     def _on_ndisplay_change(self, event):
         new_ndisplay = event.value
-        vispy_visual_index = self._backend.vispy_visual.parent.children.index(self._backend.vispy_visual)
         if new_ndisplay == 2:
-            self._backend.vispy_visual.parent.children[vispy_visual_index].order = 0
             self.enabled = False
         else:
             self.enabled = True
-            self._backend.vispy_visual.parent.children[vispy_visual_index].order = 1
 
     def _mouse_callback(self, layer, event):
         """Update the manipulated object via subclass implementations of drag/rotate behaviour."""


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/183

In this PR I connect the dims.ndisplay event to `_on_ndisplay_changed` in base_manipulator init.
Then, in `_on_ndisplay_changed` I change the node.order so that the manipulator is properly restored when toggling back to 3D.

This fixes the issue.

Question:
There is another unconnected callback here:
https://github.com/napari-threedee/napari-threedee/blob/fdfac7246d18bb72dc5ec3c0989a4c6b252b14a7/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py#L202-L206

Would the node.order be better there? Should I connect that one instead?

Or should that be removed? The mouse/drag callbacks are handled in base_manipulator:
https://github.com/napari-threedee/napari-threedee/blob/fdfac7246d18bb72dc5ec3c0989a4c6b252b14a7/src/napari_threedee/manipulators/base_manipulator.py#L204-L220

(in base_manipulator on_ndisplay_change the manipulator is disabled in 2d and enabled in 3d)

Or should I connect the event in each manipulator type, under their `def _connect_events(self):`

Finally, in `base_manipulator`:
https://github.com/napari-threedee/napari-threedee/blob/fdfac7246d18bb72dc5ec3c0989a4c6b252b14a7/src/napari_threedee/manipulators/base_manipulator.py#L222-L224

The last line, the `remove`, it doesn't actually work. the list doesn't get modified.
I'm not sure how to actually remove the manipulator visual. Any advice?