### PR TITLE
fix translator handle position and segment

### DIFF
--- a/src/napari_threedee/_backend/manipulator/translator.py
+++ b/src/napari_threedee/_backend/manipulator/translator.py
@@ -11,7 +11,7 @@ class Translator(BaseModel, _Grabbable):
     """Axis, offset from origin with a handle at the base."""
     axis: AxisModel
     length: float = 3
-    distance_from_origin: float = 21  # distance of start point from origin
+    distance_from_origin: float = 20  # distance of start point from origin
 
     @property
     def start_point(self) -> np.ndarray:
@@ -27,7 +27,7 @@ class Translator(BaseModel, _Grabbable):
 
     @property
     def handle_point(self) -> np.ndarray:
-        return self.start_point
+        return self.end_point
 
     @classmethod
     def from_string(cls, axis: str):

--- a/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
+++ b/src/napari_threedee/_backend/manipulator/vispy_visual_data.py
@@ -117,7 +117,7 @@ class ManipulatorHandleData(BaseModel):
     @classmethod
     def from_translator(cls, translator: Translator):
         return cls(
-            points=translator.start_point.reshape((1, 3)),
+            points=translator.end_point.reshape((1, 3)),
             colors=translator.axis.color.reshape((1, 4)),
             axis_identifiers=np.array([translator.axis.id])
         )


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/179
Alternative to: https://github.com/napari-threedee/napari-threedee/pull/180

So in this PR I eliminate the small gap and put the handle at the *end* of the extra segment.
Here's what it looks like with a bit of zoom -- when zoomed out and the handle Marker covers much of the extra segment. 
<img width="1190" alt="image" src="https://github.com/napari-threedee/napari-threedee/assets/76622105/ca3def96-f28d-46f8-95fc-2e8849a87611">
