### PR TITLE
[Enh] Disable render plane manipulator if depication switched to volume

### DIFF
--- a/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
+++ b/src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from napari_threedee._backend.manipulator.manipulator_model import ManipulatorModel
+from napari_threedee.manipulators import RenderPlaneManipulator
 
 
 def test_instantiation():
@@ -46,3 +47,14 @@ def test_selected_object_type_update():
     assert manipulator.selected_object_type == 'rotator'
     manipulator.selected_axis_id = None
     assert manipulator.selected_object_type is None
+
+def test_depiction_change(viewer_with_plane_3d):
+    """Test the manipulator is disabled when switching to volume depiction."""
+    viewer = viewer_with_plane_3d
+    manipulator = RenderPlaneManipulator(viewer=viewer, layer=viewer.layers[0])
+
+    assert viewer.layers[0].depiction == 'plane'
+    assert manipulator.enabled
+
+    viewer.layers[0].depiction = 'volume'
+    assert manipulator.enabled is False

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -19,6 +19,7 @@ class RenderPlaneManipulator(BaseManipulator):
         self.layer.plane.events.position.connect(self._update_transform)
         self.layer.plane.events.normal.connect(self._update_transform)
         self.layer.events.visible.connect(self._on_visibility_change)
+        self.layer.events.depiction.connect(self._on_depiction_change)
         self._viewer.layers.events.removed.connect(self._disable_and_remove)
 
     def _disconnect_events(self):
@@ -49,3 +50,9 @@ class RenderPlaneManipulator(BaseManipulator):
         with self.layer.plane.events.normal.blocker(self._update_transform):
             z_vector_data = world_to_data_normal(vector=self.z_vector, layer=self.layer)
             self.layer.plane.normal = z_vector_data
+
+    def _on_depiction_change(self):
+        if self.layer.depiction == 'volume':
+            self.enabled = False
+        else:
+            self.enabled = True

--- a/src/napari_threedee/manipulators/render_plane_manipulator.py
+++ b/src/napari_threedee/manipulators/render_plane_manipulator.py
@@ -52,7 +52,7 @@ class RenderPlaneManipulator(BaseManipulator):
             self.layer.plane.normal = z_vector_data
 
     def _on_depiction_change(self):
-        if self.layer.depiction == 'volume':
-            self.enabled = False
-        else:
+        if self.layer.depiction == 'plane':
             self.enabled = True
+        else:
+            self.enabled = False


### PR DESCRIPTION
Ran into this recently:
If you have a 3D layer in plane mode with a render plane manipulator and you switch the 3d display depiction from plane to volume, the render plane manipulator persists inside the volume. 
It's wierd and not really what I would expect.

With this PR I connect to the depiction event and disable the manipulator in volume view. It comes back when you switch back to plane.