### PR TITLE
update MacOS version in Actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-13]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
Github actions moved `macos-latest` to arm. Temporary fix based on  https://github.com/napari/napari/pull/6858