### PR TITLE
[maint] ensure all imports are in install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,10 +34,16 @@ install_requires =
 	einops
 	imageio>=2.5.0,!=2.11.0,!=2.22.1
 	libigl
-	npe2
+	magicgui
 	napari
 	numpy
+	pandas
+	psygnal
+	pydantic
 	qtpy
+	scipy
+	superqt
+	vispy
 	zarr
 	morphosamplers
 
@@ -62,6 +68,7 @@ dev =
 	pytest
 	pytest-qt
 	qtgallery
+	scikit-image[data]
 
 [options.package_data]
 napari_threedee = napari.yaml


### PR DESCRIPTION
I'm trying to figure out why conda-forge feedstock isn't getting any updates.
In the process I noticed the conda-forge bot commenting on missing dependencies in the recipe. Sure enough, they are missing in setup.cfg. Everything works because they are napari requirements, but I think everything that is imported in this codebase should be in setup.cfg.

Note I removed npe2, my understanding is that plugins don't depend on/use it.