### PR TITLE
[bugfix] pass scalar sphere_diameter value from handle_size array

### DIFF
--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -161,7 +161,8 @@ class NapariManipulatorBackend:
             click_point=click_point,
             view_direction=view_direction,
             sphere_centroids=einops.rearrange(transformed_handle_points, 'b xyz 1 -> b xyz'),
-            sphere_diameter=self.vispy_visual_data.translator_handle_data.handle_size
+            # all the handle_sizes are the same, so we can just use the first one
+            sphere_diameter=self.vispy_visual_data.translator_handle_data.handle_size[0]
         )
         if selection is None:
             return None


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/192

So previously it worked because translators had a scalar `handle_size`. But after changes to make setters, handle_size is an array. Now all the handle_size for rotators and translators are set together, to the same value, so which element you use doesn't matter, as long as a scalar is passed as `sphere_diameter`.

This is not the most elegant way of solving this. But I don't think can access BaseManipulator.radius here...
One could pass the arrays of handle_size instead of constructing an array of sphere_diameter in `select_sphere_from_click`? But that's a bigger refactor probably to ensure it doesn't break something else.