### PR TITLE
bugfix: disconnect events when layer is removed.

### DIFF
--- a/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
+++ b/src/napari_threedee/_backend/manipulator/napari_manipulator_backend.py
@@ -40,10 +40,10 @@ class NapariManipulatorBackend:
             self._connect_mouse_callback()
 
         self._connect_transformation_events()
+        self._connect_ndisplay_event()
         self.vispy_visual.update()
         self.vispy_visual.update_visuals_from_manipulator_visual_data()
 
-        self._viewer.dims.events.ndisplay.connect(self._on_ndisplay_change)
 
 
     @property
@@ -76,6 +76,12 @@ class NapariManipulatorBackend:
     def _connect_transformation_events(self):
         # updating the model should update the view
         self.manipulator_model.events.origin.connect(self._on_transformation_changed)
+    
+    def _connect_ndisplay_event(self):
+        self._viewer.dims.events.ndisplay.connect(self._on_ndisplay_change)
+
+    def _disconnect_ndisplay_event(self):
+        self._viewer.dims.events.ndisplay.disconnect(self._on_ndisplay_change)
 
     def _connect_mouse_callback(self):
         add_mouse_callback_safe(

--- a/src/napari_threedee/manipulators/base_manipulator.py
+++ b/src/napari_threedee/manipulators/base_manipulator.py
@@ -289,6 +289,9 @@ class BaseManipulator(N3dComponent, ABC):
     def _disable_and_remove(self):
         self.enabled = False
         self._backend.vispy_visual.parent = None
+        self._disconnect_events()
+        self._backend._disconnect_ndisplay_event()
+        self._viewer.dims.events.ndisplay.disconnect(self._on_ndisplay_change)
 
 
     def _on_ndisplay_change(self, event):


### PR DESCRIPTION
Closes https://github.com/napari-threedee/napari-threedee/issues/195

In this PR I try to disconnect events when the layer is removed.
It resolves the issue, but I'm not sure if it's sufficient/complete teardown.
