### PR TITLE
bugfix: use handle_size/2 for the in_slice_matches

### DIFF
--- a/src/napari_threedee/utils/selection_utils.py
+++ b/src/napari_threedee/utils/selection_utils.py
@@ -177,9 +177,8 @@ def select_sphere_from_click(
     handle_sizes = np.tile(sphere_diameter, (n_spheres, 1))
     distances = abs(rotated_points[:, :2] - rotated_click_point[:2])
 
-    # the -1 accounts for the edge width
     in_slice_matches = np.all(
-        distances <= ((handle_sizes - 1) / 2) - 1.5,
+        distances <= (handle_sizes / 2),
         axis=1,
     )
     indices = np.where(in_slice_matches)[0]


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/196

This PR will make every value of `handle_size` work as long as it's non-zero.
The click radius includes the border now.
