### PR TITLE
[bugfix] remove non-existent writer and reader contributions

### DIFF
--- a/src/napari_threedee/napari.yaml
+++ b/src/napari_threedee/napari.yaml
@@ -50,15 +50,15 @@ contributions:
       title: Create camera spline control widget
       python_name: napari_threedee.dock_widgets:QtCameraSpline
 
-    # Reader
-    - id: napari-threedee.read_n3d
-      title: Read ".n3d" files
-      python_name: napari_threedee.annotators.io._napari:read_n3d_zarr
+    # # Reader
+    # - id: napari-threedee.read_n3d
+    #   title: Read ".n3d" files
+    #   python_name: napari_threedee.annotators.io._napari:read_n3d_zarr
 
-    # Writers
-    - id: napari-threedee.write_n3d
-      title: Save points layer to n3d
-      python_name: napari_threedee.annotators.io._napari:write_n3d_zarr
+    # # Writers
+    # - id: napari-threedee.write_n3d
+    #   title: Save points layer to n3d
+    #   python_name: napari_threedee.annotators.io._napari:write_n3d_zarr
 
 
   widgets:
@@ -98,15 +98,15 @@ contributions:
     - command: napari-threedee.QtCameraSplineWidget
       display_name: camera spline control
 
-  writers:
-    - command: napari-threedee.write_n3d
-      layer_types:
-        - points
-      filename_extensions:
-        - .n3d
+  # writers:
+  #   - command: napari-threedee.write_n3d
+  #     layer_types:
+  #       - points
+  #     filename_extensions:
+  #       - .n3d
 
-  readers:
-    - command: napari-threedee.read_n3d
-      filename_patterns:
-        - '*.n3d'
-      accepts_directories: true
+  # readers:
+  #   - command: napari-threedee.read_n3d
+  #     filename_patterns:
+  #       - '*.n3d'
+  #     accepts_directories: true


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/134
I also ran into the issue where the (non-existent) writer was the default for Points.

The `io` module was removed in https://github.com/napari-threedee/napari-threedee/pull/96
But the reader/writer remain in the manifest.

In this PR i comment out the contributions in case in the future we want to put them back.