### PR TITLE
[pydantic2] make optional optional

### DIFF
--- a/src/napari_threedee/_backend/manipulator/manipulator_model.py
+++ b/src/napari_threedee/_backend/manipulator/manipulator_model.py
@@ -17,8 +17,8 @@ class ManipulatorModel(EventedModel):
     origin: Tuple[float, float, float] = Field(default_factory=lambda: np.zeros(3))
     rotation_matrix: np.ndarray = Field(default_factory=lambda: np.eye(3))
 
-    selected_axis_id: Optional[int]
-    selected_object_type: Optional[Literal['translator', 'rotator']]
+    selected_axis_id: Optional[int] = None
+    selected_object_type: Optional[Literal['translator', 'rotator']] = None
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
napari-threedee doesn't pin back pydantic, but morphosamplers does.
In working on lifting the pin in morphosamplers, I got validation errors when running tests here with pydantic v2, e.g.:
```
_______________________________________ test_instantiation _______________________________________

    def test_instantiation():
>       manipulator = ManipulatorModel(
            central_axes='xyz',
            translators='xy',
            rotators='z',
        )

src/napari_threedee/_backend/manipulator/_tests/test_manipulator.py:8: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_model_self_ = ManipulatorModel()
data = {'central_axes': 'xyz', 'rotators': 'z', 'translators': 'xy'}

    def __init__(_model_self_, **data: Any) -> None:
>       super().__init__(**data)
E       pydantic_core._pydantic_core.ValidationError: 2 validation errors for ManipulatorModel
E       selected_axis_id
E         Field required [type=missing, input_value={'central_axes': 'xyz', '...: 'xy', 'rotators': 'z'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.7/v/missing
E       selected_object_type
E         Field required [type=missing, input_value={'central_axes': 'xyz', '...: 'xy', 'rotators': 'z'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.7/v/missing

../miniforge3/envs/morpho-test/lib/python3.10/site-packages/psygnal/_evented_model.py:467: ValidationError
```

I believe this is due to: https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields

So in this PR I change the two fields of ManipulatorModel from `Optional[]` to `Optional[] = None` to make them not required.
With this change, tests pass for me with pydantic2 and pydantic1.