### PR TITLE
[bugfix] point annotator: check if plane layer is selected

### DIFF
--- a/src/napari_threedee/annotators/points/annotator.py
+++ b/src/napari_threedee/annotators/points/annotator.py
@@ -27,7 +27,9 @@ class PointAnnotator(N3dComponent):
         self.enabled = enabled
 
     def _mouse_callback(self, viewer, event):
-        if (self.image_layer is None) or (self.points_layer is None):
+        if ((self.image_layer is None) or 
+            (self.points_layer is None) or 
+            (viewer.layers.selection.active is not self.image_layer)):
             return
         add_point_on_plane(
             viewer=viewer,


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/194

This should suffice to fix the issue, without deactivating the annotators. Just check whether the linked image layer  is selected before adding a point. Tested this locally with the setup from the issue (2 image layers, 2 points layers, 2 annotators) and switching selected image layers put the points at the right spots on the right layers.