### PR TITLE
Use layer mouse callback for points annotator

### DIFF
--- a/src/napari_threedee/annotators/points/annotator.py
+++ b/src/napari_threedee/annotators/points/annotator.py
@@ -30,7 +30,7 @@ class PointAnnotator(N3dComponent):
         if (self.image_layer is None) or (self.points_layer is None):
             return
         add_point_on_plane(
-            viewer=viewer,
+            viewer=self.viewer,
             event=event,
             points_layer=self.points_layer,
             image_layer=self.image_layer
@@ -50,11 +50,13 @@ class PointAnnotator(N3dComponent):
         self.points_layer = points_layer
 
     def _on_enable(self):
-        add_mouse_callback_safe(
-            self.viewer.mouse_drag_callbacks, self._mouse_callback
-        )
+        if self.image_layer is not None:
+            add_mouse_callback_safe(
+                self.image_layer.mouse_drag_callbacks, self._mouse_callback, index=0
+            )
 
     def _on_disable(self):
-        remove_mouse_callback_safe(
-            self.viewer.mouse_drag_callbacks, self._mouse_callback
-        )
+        if self.image_layer is not None:
+            remove_mouse_callback_safe(
+                self.image_layer.mouse_drag_callbacks, self._mouse_callback
+            )


### PR DESCRIPTION
Closes #194 
Alternative to https://github.com/napari-threedee/napari-threedee/pull/201

In the other PR we determined that manipulators work because they use layer mouse events not viewer ones
https://github.com/napari-threedee/napari-threedee/pull/201#issuecomment-2108806063
I noticed that labels annotator also uses layer events:
https://github.com/napari-threedee/napari-threedee/blob/8fbe1631d3f16c90e33560ed053d5ea2045c94fb/src/napari_threedee/annotators/label/annotator.py#L53-L56

So this PR implements that strategy for the points annotator.

