### PR TITLE
[Docs] Update mkdocs.yml to add copy button to code cells

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ theme:
         name: Switch to light mode
 
   features:
-    - navigation.instant
+    #- navigation.instant
     #- navigation.tabs
     #- navigation.top
     #- navigation.tracking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ theme:
     # - content.code.annotate
     # - navigation.sections
     - content.tabs.link
+    - content.code.copy
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/213

This should put in a copy button for code cells, per mkdocs-material docs:
https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button