### PR TITLE
[Docs] update How To 1 (render plane manipulator)

### DIFF
--- a/docs/how_to/render_plane_manipulator.md
+++ b/docs/how_to/render_plane_manipulator.md
@@ -19,7 +19,7 @@ the rendering plane.
      napari
      ```
 
-2. Load the "HIV virus-like particles tomogram" image from the File menu: **File -> Open Sample -> HIV virus-like particles tomogram**. Note that this will download the [sample image from Zenodo](https://doi.org/10.5281/zenodo.6504891) (~470 Mb) so it make take some time. If you have previously opened the sample image, it should be cached and will not download again.
+2. Load the "HIV virus-like particles tomogram" image from the File menu: **File -> Open Sample -> HIV virus-like particles tomogram**. Note that this will download the ~470 Mb sample image from Zenodo([https://doi.org/10.5281/zenodo.6504891](https://doi.org/10.5281/zenodo.6504891)) so it make take some time. If you have previously opened the sample image, it should be cached and will not be downloaded again.
 
 	![screenshot of the hiv tomogram](https://user-images.githubusercontent.com/1120672/207310777-1cfdb146-e5b9-43fb-a740-6af137ed9df5.png)
 

--- a/docs/how_to/render_plane_manipulator.md
+++ b/docs/how_to/render_plane_manipulator.md
@@ -39,7 +39,7 @@ the rendering plane.
 	
 	![plane rendering mode](https://user-images.githubusercontent.com/1120672/207311620-0494f9cf-3059-40d4-902e-37f026556c56.png)
 
-5. Open the render plane manipulator plugin from the menu: **Plugins -> napari-threedee -> render plane manipulator**. You will see the render plane manipulator appear on the rendering plane.
+5. Open the render plane manipulator plugin from the menu: **Plugins -> napari-threedee -> render plane manipulator**. You will see the render plane manipulator appear in the corner of the rendering plane. You can double-click with the left mouse button (or hold down the Shift key while clicking) to reposition the manipulator. Note that depending on your versions of `napari-threedee` and napari there may be a subtle visual difference between what you see in `napari` and the screenshots/videos here.
 
 	![render plane manipulator](https://user-images.githubusercontent.com/1120672/207311868-d6a0d972-37ea-4e79-92b1-3923a058221b.png)
 	
@@ -52,6 +52,6 @@ the rendering plane.
 
 	![type:video](https://user-images.githubusercontent.com/1120672/207312303-e81f652a-3fae-476f-abee-e19227b2b6c3.mov)
 
-	If you would like to change the center of rotation, you can press the shift key while clicking on the plane with the left mouse button to move the manipulator.
+	If you would like to change the center of rotation, you can double-click with the left mouse button (or hold down the Shift key while clicking) on the plane with the left mouse button to move the manipulator.
 	
 	![type:video](https://user-images.githubusercontent.com/1120672/207312430-74b95837-0718-4b9b-a2dd-b9fed0565e21.mov)

--- a/docs/how_to/render_plane_manipulator.md
+++ b/docs/how_to/render_plane_manipulator.md
@@ -39,16 +39,18 @@ the rendering plane.
 	
 	![plane rendering mode](https://user-images.githubusercontent.com/1120672/207311620-0494f9cf-3059-40d4-902e-37f026556c56.png)
 
-5. Open the render plane manipulator plugin from the menu: **Plugins -> napari-threedee -> render plane manipulator**. You will see the render plane manipulator appear in the corner of the rendering plane. You can double-click with the left mouse button (or hold down the Shift key while clicking) to reposition the manipulator. Note that depending on your versions of `napari-threedee` and napari there may be a subtle visual difference between what you see in `napari` and the screenshots/videos here.
+5. Open the render plane manipulator widget using the menu: **Plugins -> napari-threedee -> render plane manipulator**. You will see the widget appear on the right side of the napari viewer. Ensure that "HIV tomogram" is selected in the "layers" dropdown box and then click the "activate" button to activate the manipulator function. A render plane manipulator will appear in the corner of the rendering plane. 
+
+6. You can double-click with the left mouse button (or hold down the Shift key while clicking) to reposition the manipulator. Note that depending on your versions of `napari-threedee` and napari there may be a subtle visual difference between what you see in `napari` and the screenshots/videos here.
 
 	![render plane manipulator](https://user-images.githubusercontent.com/1120672/207311868-d6a0d972-37ea-4e79-92b1-3923a058221b.png)
 	
 
-6. You can click and drag the translator on the manipulator to translate the plane along its normal.
+7. You can click and drag the translator on the manipulator to translate the plane along its normal.
 
 	![type:video](https://user-images.githubusercontent.com/1120672/207312152-d9d49bfd-04dc-4b27-827b-04282c512e48.mov)
 
-7. You can click and drag the rotator to rotate the plane around the manipulator.
+8. You can click and drag the rotator to rotate the plane around the manipulator.
 
 	![type:video](https://user-images.githubusercontent.com/1120672/207312303-e81f652a-3fae-476f-abee-e19227b2b6c3.mov)
 

--- a/docs/how_to/render_plane_manipulator.md
+++ b/docs/how_to/render_plane_manipulator.md
@@ -19,7 +19,7 @@ the rendering plane.
      napari
      ```
 
-2. Load the "HIV virus-like particles tomogram" image from the File menu: File -> Open Sample -> HIV virus-like particle tomogram. Note that this will download the sample image so it make take some time. If you have previously opened the sample image, it should be cached and will not download again.
+2. Load the "HIV virus-like particles tomogram" image from the File menu: **File -> Open Sample -> HIV virus-like particles tomogram**. Note that this will download the [sample image from Zenodo](https://doi.org/10.5281/zenodo.6504891) (~470 Mb) so it make take some time. If you have previously opened the sample image, it should be cached and will not download again.
 
 	![screenshot of the hiv tomogram](https://user-images.githubusercontent.com/1120672/207310777-1cfdb146-e5b9-43fb-a740-6af137ed9df5.png)
 
@@ -39,7 +39,7 @@ the rendering plane.
 	
 	![plane rendering mode](https://user-images.githubusercontent.com/1120672/207311620-0494f9cf-3059-40d4-902e-37f026556c56.png)
 
-5. Open the render plane manipulator plugin from the menu: Plugins -> napari-threedee -> render plane manipulator. You will see the render plane manipulator appear on the rendering plane.
+5. Open the render plane manipulator plugin from the menu: **Plugins -> napari-threedee -> render plane manipulator**. You will see the render plane manipulator appear on the rendering plane.
 
 	![render plane manipulator](https://user-images.githubusercontent.com/1120672/207311868-d6a0d972-37ea-4e79-92b1-3923a058221b.png)
 	

--- a/src/napari_threedee/napari.yaml
+++ b/src/napari_threedee/napari.yaml
@@ -105,7 +105,7 @@ contributions:
 
   sample_data:
     - command: napari-threedee.hiv_particles
-      display_name: HIV virus-like particle tomogra
+      display_name: HIV virus-like particles tomogram
       key: unique_id.1
 
   # writers:


### PR DESCRIPTION
Closes: https://github.com/napari-threedee/napari-threedee/issues/205

In the PR I correct the napari.yaml display name of the sample to be consistent and do minor copy-edits to the text:
1. provide a link to Zenodo
2. warn about sample file size
3. warn that there may be subtle visual differences depending on versions of n3d and napari
4. specify that double-click moves the manipulator (that is the actual napari shortcut, shift-click working is technically a bug? see https://github.com/napari/napari/blob/main/napari/layers/image/_image_mouse_bindings.py )
