### PR TITLE
add 'add point on key press' functionality

### DIFF
--- a/docs/examples/library/point_annotator_library.py
+++ b/docs/examples/library/point_annotator_library.py
@@ -15,7 +15,7 @@ from napari_threedee.annotators import PointAnnotator
 viewer = napari.Viewer(ndisplay=3)
 
 # generate 3d image data
-blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=4).astype(float)
+blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(float)
 
 # add image layer to viewer (rendering as a plane)
 image_layer = viewer.add_image(

--- a/docs/examples/library/point_annotator_library.py
+++ b/docs/examples/library/point_annotator_library.py
@@ -15,7 +15,7 @@ from napari_threedee.annotators import PointAnnotator
 viewer = napari.Viewer(ndisplay=3)
 
 # generate 3d image data
-blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=3).astype(float)
+blobs = data.binary_blobs(length=64, volume_fraction=0.1, n_dim=4).astype(float)
 
 # add image layer to viewer (rendering as a plane)
 image_layer = viewer.add_image(

--- a/src/napari_threedee/annotators/points/annotator.py
+++ b/src/napari_threedee/annotators/points/annotator.py
@@ -5,10 +5,9 @@ import napari.types
 import numpy as np
 
 from napari_threedee._backend.threedee_model import N3dComponent
-from napari_threedee.annotators.points.validation import validate_layer
-from napari_threedee.utils.mouse_callbacks import add_point_on_plane
+from napari_threedee.utils.mouse_callbacks import on_mouse_alt_click_add_point_on_plane
 from napari_threedee.utils.napari_utils import add_mouse_callback_safe, \
-    remove_mouse_callback_safe
+    remove_mouse_callback_safe, add_point_on_plane
 
 
 class PointAnnotator(N3dComponent):
@@ -26,14 +25,23 @@ class PointAnnotator(N3dComponent):
         self.points_layer = points_layer
         self.enabled = enabled
 
-    def _mouse_callback(self, viewer, event):
+    def _add_point_on_mouse_alt_click(self, layer, event):
         if (self.image_layer is None) or (self.points_layer is None):
             return
-        add_point_on_plane(
+        on_mouse_alt_click_add_point_on_plane(
             viewer=self.viewer,
             event=event,
             points_layer=self.points_layer,
             image_layer=self.image_layer
+        )
+
+    def _add_point_on_key_press(self, *args):
+        if (self.image_layer is None) or (self.points_layer is None):
+            return
+        add_point_on_plane(
+            viewer=self.viewer,
+            image_layer=self.image_layer,
+            points_layer=self.points_layer,
         )
 
     def _create_points_layer(self) -> napari.layers.Points:
@@ -52,11 +60,12 @@ class PointAnnotator(N3dComponent):
     def _on_enable(self):
         if self.image_layer is not None:
             add_mouse_callback_safe(
-                self.image_layer.mouse_drag_callbacks, self._mouse_callback, index=0
+                self.image_layer.mouse_drag_callbacks, self._add_point_on_mouse_alt_click, index=0
             )
+            self.image_layer.bind_key('a', self._add_point_on_key_press)
 
     def _on_disable(self):
         if self.image_layer is not None:
             remove_mouse_callback_safe(
-                self.image_layer.mouse_drag_callbacks, self._mouse_callback
+                self.image_layer.mouse_drag_callbacks, self._add_point_on_mouse_alt_click
             )

--- a/src/napari_threedee/annotators/surfaces/annotator.py
+++ b/src/napari_threedee/annotators/surfaces/annotator.py
@@ -12,9 +12,9 @@ from typing import Tuple, Union, Optional, Dict
 from morphosamplers.surface_spline import GriddedSplineSurface
 
 from napari_threedee._backend.threedee_model import N3dComponent
-from napari_threedee.utils.mouse_callbacks import add_point_on_plane
+from napari_threedee.utils.mouse_callbacks import on_mouse_alt_click_add_point_on_plane
 from napari_threedee.utils.napari_utils import add_mouse_callback_safe, \
-    remove_mouse_callback_safe
+    remove_mouse_callback_safe, add_point_on_plane
 from .constants import (
     N3D_METADATA_KEY,
     ANNOTATION_TYPE_KEY,
@@ -197,14 +197,23 @@ class SurfaceAnnotator(N3dComponent):
     def previous_surface(self, event=None):
         self.active_surface_id -= 1
 
-    def _mouse_callback(self, viewer, event):
+    def _add_point_on_mouse_alt_click(self, viewer, event):
         if (self.image_layer is None) or (self.points_layer is None):
             return
-        add_point_on_plane(
+        on_mouse_alt_click_add_point_on_plane(
             viewer=viewer,
             event=event,
             points_layer=self.points_layer,
             image_layer=self.image_layer
+        )
+
+    def _add_point_on_key_press(self, *args):
+        if (self.image_layer is None) or (self.points_layer is None):
+            return
+        add_point_on_plane(
+            viewer=self.viewer,
+            image_layer=self.image_layer,
+            points_layer=self.points_layer,
         )
 
     def _create_points_layer(self) -> Optional[Points]:
@@ -252,15 +261,16 @@ class SurfaceAnnotator(N3dComponent):
     def _on_enable(self):
         if self.points_layer is not None:
             add_mouse_callback_safe(
-                self.viewer.mouse_drag_callbacks, self._mouse_callback
+                self.viewer.mouse_drag_callbacks, self._add_point_on_mouse_alt_click
             )
+            self.image_layer.bind_key('a', self._add_point_on_key_press)
             self.points_layer.events.data.connect(self._on_point_data_changed)
             self.viewer.bind_key('n', self.next_spline, overwrite=True)
             self.viewer.layers.selection.active = self.image_layer
 
     def _on_disable(self):
         remove_mouse_callback_safe(
-            self.viewer.mouse_drag_callbacks, self._mouse_callback
+            self.viewer.mouse_drag_callbacks, self._add_point_on_mouse_alt_click
         )
         if self.points_layer is not None:
             self.points_layer.events.data.disconnect(

--- a/src/napari_threedee/utils/_tests/test_mouse_callbacks.py
+++ b/src/napari_threedee/utils/_tests/test_mouse_callbacks.py
@@ -3,7 +3,7 @@ from typing import Tuple, List
 
 import numpy as np
 
-from napari_threedee.utils.mouse_callbacks import add_point_on_plane
+from napari_threedee.utils.mouse_callbacks import on_mouse_alt_click_add_point_on_plane
 
 @dataclass
 class MockMouseEvent:
@@ -27,7 +27,7 @@ def test_add_point_on_plane_3d(viewer_with_plane_and_points_3d):
         modifiers = ['Alt']
     )
 
-    add_point_on_plane(
+    on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_3d,
         event=event,
         points_layer=points_layer,
@@ -57,7 +57,7 @@ def test_add_point_on_plane_4d(viewer_with_plane_and_points_4d):
         modifiers = ['Alt']
     )
 
-    add_point_on_plane(
+    on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_4d,
         event=event,
         points_layer=points_layer,
@@ -86,7 +86,7 @@ def test_add_point_on_plane_same_scale_3d(viewer_with_plane_and_points_3d):
     )
 
     # plane position is (14, 14, 14), in data coordinates 
-    add_point_on_plane(
+    on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_3d,
         event=event,
         points_layer=points_layer,
@@ -124,7 +124,7 @@ def test_add_point_on_plane_same_scale_4d(viewer_with_plane_and_points_4d):
     )
 
     # plane position is (14, 14, 14), in data coordinates 
-    add_point_on_plane(
+    on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_4d,
         event=event,
         points_layer=points_layer,
@@ -171,7 +171,7 @@ def test_add_point_on_plane_different_scale_3d(make_napari_viewer):
         view_direction=np.array([-1, 0, 0]),
         modifiers=["Alt"]
     )
-    add_point_on_plane(
+    on_mouse_alt_click_add_point_on_plane(
         viewer=viewer,
         event=event,
         points_layer=points_layer,

--- a/src/napari_threedee/utils/_tests/test_mouse_callbacks.py
+++ b/src/napari_threedee/utils/_tests/test_mouse_callbacks.py
@@ -7,8 +7,6 @@ from napari_threedee.utils.mouse_callbacks import on_mouse_alt_click_add_point_o
 
 @dataclass
 class MockMouseEvent:
-    position: np.ndarray
-    view_direction: np.ndarray
     modifiers: List[str]
 
 def test_add_point_on_plane_3d(viewer_with_plane_and_points_3d):
@@ -22,10 +20,10 @@ def test_add_point_on_plane_3d(viewer_with_plane_and_points_3d):
     viewer.dims.ndisplay = 3
 
     event = MockMouseEvent(
-        position = (14, 14, 14),
-        view_direction = np.array((1, 0, 0)),
         modifiers = ['Alt']
     )
+    viewer.cursor.position = (14, 14, 14)
+    viewer.camera.set_view_direction((1, 0, 0))
 
     on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_3d,
@@ -52,10 +50,10 @@ def test_add_point_on_plane_4d(viewer_with_plane_and_points_4d):
     viewer.dims.set_current_step(0, slice_index)
 
     event = MockMouseEvent(
-        position = (0, 14, 14, 14),
-        view_direction = np.array((0, 1, 0, 0)),
         modifiers = ['Alt']
     )
+    viewer.cursor.position = (0, 14, 14, 14)
+    viewer.camera.set_view_direction((1, 0, 0))
 
     on_mouse_alt_click_add_point_on_plane(
         viewer=viewer_with_plane_and_points_4d,
@@ -80,10 +78,10 @@ def test_add_point_on_plane_same_scale_3d(viewer_with_plane_and_points_3d):
 
     # the event is in world (scaled) coordinates
     event = MockMouseEvent(
-        position = (14, 14, 14),
-        view_direction = np.array((1, 0, 0)),
         modifiers = ['Alt']
     )
+    viewer.cursor.position = (14, 14, 14)
+    viewer.camera.set_view_direction((1, 0, 0))
 
     # plane position is (14, 14, 14), in data coordinates 
     on_mouse_alt_click_add_point_on_plane(
@@ -118,10 +116,10 @@ def test_add_point_on_plane_same_scale_4d(viewer_with_plane_and_points_4d):
 
     # the event is in world (scaled) coordinates
     event = MockMouseEvent(
-        position = (0, 14, 14, 14),
-        view_direction = np.array((0, 1, 0, 0)),
         modifiers = ['Alt']
     )
+    viewer.cursor.position = (0, 14, 14, 14)
+    viewer.camera.set_view_direction((1, 0, 0))
 
     # plane position is (14, 14, 14), in data coordinates 
     on_mouse_alt_click_add_point_on_plane(
@@ -167,10 +165,11 @@ def test_add_point_on_plane_different_scale_3d(make_napari_viewer):
     # add the point
     event = MockMouseEvent(
         # world (scaled) coordinates
-        position=np.array([12, 5, 5]),
-        view_direction=np.array([-1, 0, 0]),
         modifiers=["Alt"]
     )
+    viewer.cursor.position = (12, 5, 5)
+    viewer.camera.set_view_direction((-1, 0, 0))
+
     on_mouse_alt_click_add_point_on_plane(
         viewer=viewer,
         event=event,

--- a/src/napari_threedee/utils/mouse_callbacks.py
+++ b/src/napari_threedee/utils/mouse_callbacks.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from napari.layers.utils.interactivity_utils import drag_data_to_projected_distance
-from napari.layers.utils.layer_utils import dims_displayed_world_to_layer
-import numpy as np
 
-from napari_threedee.utils.napari_utils import point_in_layer_bounding_box
+from napari_threedee.utils.napari_utils import add_point_on_plane
 
 if TYPE_CHECKING:
     import napari
@@ -13,7 +11,7 @@ if TYPE_CHECKING:
     from napari.utils.events import Event
 
 
-def add_point_on_plane(
+def on_mouse_alt_click_add_point_on_plane(
         viewer: napari.viewer.Viewer,
         event: Event,
         points_layer: napari.layers.Points = None,
@@ -24,51 +22,10 @@ def add_point_on_plane(
     if 'Alt' not in event.modifiers:
         return
 
-    # Early exit if image_layer isn't visible
-    if image_layer.visible is False or image_layer.depiction != 'plane':
-        return
-    # event.position and event.view_direction are in world (scaled) coordinates
-    position_world = event.position
-    view_direction_world = event.view_direction
-    ndim_world = len(position_world)
-    dims_displayed_world = np.asarray(viewer.dims.displayed)[list(viewer.dims.displayed_order)]
-
-    # use image layer data (pixel) coordinates, because that's what plane.position uses
-    position_image_data_coord = np.asarray(image_layer.world_to_data(position_world))
-    view_direction_image_data_coord = np.asarray(image_layer._world_to_data_ray(view_direction_world))
-
-    dims_displayed_image_layer = np.asarray(dims_displayed_world_to_layer(
-        dims_displayed_world,
-        ndim_world=ndim_world,
-        ndim_layer=image_layer.ndim,
-    ))
-
-    # Calculate 3d intersection of click with plane through data in image data (pixel) coordinates
-    position_image_data_3d = position_image_data_coord[dims_displayed_image_layer]
-    view_direction_image_data_3d = view_direction_image_data_coord[dims_displayed_image_layer]
-    intersection_image_data_3d = image_layer.plane.intersect_with_line(
-        line_position=position_image_data_3d,
-        line_direction=view_direction_image_data_3d
+    add_point_on_plane(
+        viewer=viewer,
+        points_layer=points_layer,
+        image_layer=image_layer,
+        replace_selected=replace_selected
     )
 
-    # Check if click was on plane by checking if intersection occurs within image layer
-    # data bounding box. If not, exit early.
-    if not point_in_layer_bounding_box(intersection_image_data_3d, image_layer):
-        return
-
-    # Transform the intersection coordinate from image layer coordinates to world coordinates
-    intersection_3d_world = np.asarray(image_layer.data_to_world(intersection_image_data_3d))[dims_displayed_image_layer]
-
-    # convert to nd in world coordinates
-    intersection_nd_world = np.asarray(viewer.dims.point)
-    intersection_nd_world[dims_displayed_image_layer] = intersection_3d_world
-
-    # Transform the the point in world coordinates to point layer data coordinates
-    intersection_3d_points = points_layer.world_to_data(intersection_3d_world)
-    intersection_nd_points = points_layer.world_to_data(intersection_nd_world)
-
-    if replace_selected:
-        points_layer.remove_selected()
-    if points_layer.data.shape[-1] < len(intersection_nd_points):
-        intersection_nd_points = intersection_3d_points
-    points_layer.add(intersection_nd_points)

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import inspect
 from functools import partial
 from typing import Optional, Tuple
 
 import magicgui
 import napari
+import napari.layers
+import napari.viewer
 import numpy as np
 from magicgui.widgets import FunctionGui
 from napari.layers import Points, Image
-
+from napari.layers.utils.layer_utils import dims_displayed_world_to_layer
 
 NAPARI_LAYER_TYPES = (
     napari.layers.Layer,
@@ -302,3 +306,61 @@ def clamp_point_to_layer_bounding_box(point: np.ndarray, layer):
     bbox = layer._display_bounding_box(dims_displayed)
     clamped_point = np.clip(point, bbox[:, 0], bbox[:, 1] - 1)
     return clamped_point
+
+
+def add_point_on_plane(
+    viewer: napari.viewer.Viewer,
+    points_layer: napari.layers.Points = None,
+    image_layer: napari.layers.Image = None,
+    replace_selected: bool = False,
+):
+    # Early exit if image_layer isn't visible
+    if image_layer.visible is False or image_layer.depiction != 'plane':
+        return
+
+    # event.position and event.view_direction are in world (scaled) coordinates
+    position_world = viewer.cursor.position
+    view_direction_world = viewer.camera.view_direction
+    ndim_world = len(position_world)
+    dims_displayed_world = np.asarray(viewer.dims.displayed)[list(viewer.dims.displayed_order)]
+
+    # use image layer data (pixel) coordinates, because that's what plane.position uses
+    position_image_data_coord = np.asarray(image_layer.world_to_data(position_world))
+    view_direction_image_data_coord = np.asarray(image_layer._world_to_data_ray(view_direction_world))
+
+    dims_displayed_image_layer = np.asarray(dims_displayed_world_to_layer(
+        dims_displayed_world,
+        ndim_world=ndim_world,
+        ndim_layer=image_layer.ndim,
+    ))
+
+    # Calculate 3d intersection of click with plane through data in image data (pixel) coordinates
+    position_image_data_3d = position_image_data_coord[dims_displayed_image_layer]
+    view_direction_image_data_3d = view_direction_image_data_coord[dims_displayed_image_layer]
+    intersection_image_data_3d = image_layer.plane.intersect_with_line(
+        line_position=position_image_data_3d,
+        line_direction=view_direction_image_data_3d
+    )
+
+    # Check if click was on plane by checking if intersection occurs within image layer
+    # data bounding box. If not, exit early.
+    if not point_in_layer_bounding_box(intersection_image_data_3d, image_layer):
+        return
+
+    # Transform the intersection coordinate from image layer coordinates to world coordinates
+    intersection_3d_world = np.asarray(image_layer.data_to_world(intersection_image_data_3d))[
+        dims_displayed_image_layer]
+
+    # convert to nd in world coordinates
+    intersection_nd_world = np.asarray(viewer.dims.point)
+    intersection_nd_world[dims_displayed_image_layer] = intersection_3d_world
+
+    # Transform the the point in world coordinates to point layer data coordinates
+    intersection_3d_points = points_layer.world_to_data(intersection_3d_world)
+    intersection_nd_points = points_layer.world_to_data(intersection_nd_world)
+
+    if replace_selected:
+        points_layer.remove_selected()
+    if points_layer.data.shape[-1] < len(intersection_nd_points):
+        intersection_nd_points = intersection_3d_points
+    points_layer.add(intersection_nd_points)


### PR DESCRIPTION
this PR adds the ability to add points onto planes with the 'a' key in addition to the existing alt + click behavior

two reasons:
- I found myself in a desktop environment where alt clicking didn't work
- it's easier to be precise when using a trackpad

@kevinyamauchi @psobolewskiPhD what do you think? I'd like to get this in as it's stopping me from using n3d in our virtual desktops here