### PR TITLE
[Maint] remove spurious print in layer_manipulator

### DIFF
--- a/src/napari_threedee/manipulators/layer_manipulator.py
+++ b/src/napari_threedee/manipulators/layer_manipulator.py
@@ -20,7 +20,6 @@ class LayerManipulator(BaseManipulator):
 
     def _initialize_transform(self):
         self.origin = np.asarray(self.layer.data_to_world((0, 0, 0)))
-        print(self.origin)
 
     def _pre_drag(self):
         self.translate_start = self.origin.copy()


### PR DESCRIPTION
This print leaked in via https://github.com/napari-threedee/napari-threedee/pull/168/files#diff-d6de47217f7a11c7748d0951b735668702bfd7d6ed7f4f6ad764b0074de8bc07

It's not informative nor really needed, so I suggest deleting.