### PR TITLE
[Bugfix, napari 0.5.0] Just use string `a` as the keybinding for adding a point

### DIFF
--- a/src/napari_threedee/manipulators/constants.py
+++ b/src/napari_threedee/manipulators/constants.py
@@ -1,3 +1,1 @@
-from napari.utils.key_bindings import normalize_key_combo
-
-ADD_POINT_KEY = normalize_key_combo('a')
+ADD_POINT_KEY = 'a'


### PR DESCRIPTION
Closes https://github.com/napari-threedee/napari-threedee/issues/240

I think as long as the binding is just a simple character, we can safely use a string, which will work in 0.4.19 and 0.5.0