### PR TITLE
Update setup.cfg: remove napari[all] from dev

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ dev =
 	mkdocs-material
 	mkdocstrings[python]
 	mkdocs-video
-	napari[all]
 	pytest
 	pytest-qt
 	qtgallery


### PR DESCRIPTION
napari[all] intalls pyqt5, but napari can use other Qt backends
Currently, if a developer has a different Qt backend installed (e.g. PyQt6, which as of 0.5.0a is no longer an experimental backend) and installs the dev installation of napari-threedee they will get an extra Qt backend which can cause major issues in the environment.
Note: trying to launch napari without a Qt backend gives a reasonably informative message.