### PR TITLE
Update requirements.txt to include pyqt5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # See also: https://caremad.io/posts/2013/07/setup-vs-requirement/
 
 -e ".[dev]"
+pyqt5


### PR DESCRIPTION
This PR fixes broken docs workflow due to https://github.com/napari-threedee/napari-threedee/pull/245
https://github.com/napari-threedee/napari-threedee/actions/runs/9798343315/job/27056705375
Docs build used a pure [dev] install, so it's missing pyqt5:
https://github.com/psobolewskiPhD/napari-threedee/blob/ee4c0739b513395d16f84b6df27119173dbb1d91/.github/workflows/test_and_deploy.yml#L83
tests work because tox.ini specifies pyqt5:
https://github.com/napari-threedee/napari-threedee/blob/4286c63a9dd13c6352ef2217c71ff0c7598609ad/tox.ini#L30-L38

So in this PR i add pyqt5 to the docs requirements.txt