### PR TITLE
Changes for empty layer creation

### DIFF
--- a/src/napari_threedee/data_models/dipoles.py
+++ b/src/napari_threedee/data_models/dipoles.py
@@ -133,15 +133,15 @@ class N3dDipoles(N3dDataModel):
         """
 
         features = {
-            DIPOLE_ID_FEATURES_KEY: np.empty(0),
-            DIPOLE_DIRECTION_X_FEATURES_KEY: np.empty(0),
-            DIPOLE_DIRECTION_Y_FEATURES_KEY: np.empty(0),
-            DIPOLE_DIRECTION_Z_FEATURES_KEY: np.empty(0),
+            DIPOLE_ID_FEATURES_KEY: np.array([0]),
+            DIPOLE_DIRECTION_X_FEATURES_KEY: np.array([0]),
+            DIPOLE_DIRECTION_Y_FEATURES_KEY: np.array([0]),
+            DIPOLE_DIRECTION_Z_FEATURES_KEY: np.array([0]),
         }
         metadata = {N3D_METADATA_KEY: {ANNOTATION_TYPE_KEY: DIPOLE_ANNOTATION_TYPE_KEY}}
 
         # workaround for napari/napari#4213
-        dummy_data = np.zeros((0, 3))
+        dummy_data = np.array([[0, 0, 0]])
         layer = napari.layers.Points(
             data=dummy_data,
             features=features,


### PR DESCRIPTION
Hopefully this is the corrected version of the previous PR for the changes of the dipoles data model empty layer creation so that we can do annotation in tomoslice from empty layer :crossed_fingers: 


