### PR TITLE
Correction for 0 dipole vector norm

### DIFF
--- a/src/napari_threedee/annotators/dipoles/annotator.py
+++ b/src/napari_threedee/annotators/dipoles/annotator.py
@@ -156,10 +156,9 @@ class DipoleAnnotator(N3dComponent):
         dipole_position_3d = self.active_dipole_position[displayed_dims]
         direction = dipole_north_position_3d - dipole_position_3d
         norm = np.linalg.norm(direction)
-        if norm == 0:
-            self.viewer.status = 'vector norm = 0'
+        if np.abs(norm) < 1e-10:
             return
-        direction = direction / np.linalg.norm(direction)
+        direction = direction / norm
         self._update_active_dipole_direction(direction=direction)
         self._update_current_properties(direction=direction)
         self._update_dipoles()

--- a/src/napari_threedee/annotators/dipoles/annotator.py
+++ b/src/napari_threedee/annotators/dipoles/annotator.py
@@ -155,6 +155,10 @@ class DipoleAnnotator(N3dComponent):
         )
         dipole_position_3d = self.active_dipole_position[displayed_dims]
         direction = dipole_north_position_3d - dipole_position_3d
+        norm = np.linalg.norm(direction)
+        if norm == 0:
+            self.viewer.status = 'vector norm = 0'
+            return
         direction = direction / np.linalg.norm(direction)
         self._update_active_dipole_direction(direction=direction)
         self._update_current_properties(direction=direction)


### PR DESCRIPTION
A small addition to skip when vector norm is 0 so that there are no errors while drawing the vector in tomoslice  