### PR TITLE
don't run codecov on macos right now

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -64,6 +64,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
+        if: runner.os != 'macOS'
         uses: codecov/codecov-action@v3
 
   docs:


### PR DESCRIPTION
codecov on macos is causing failures... 
https://github.com/napari-threedee/napari-threedee/actions/runs/10924809433

this is blocking deployment so temporarily disabling