### PR TITLE
Update test_and_deploy.yml to drop 3.8, add 3.12 and arm64 macOS

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-13]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        platform: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Whoops, didn't realize I could make a branch on this repo 👀 
Anyhow, this PR updates CI to drop python 3.8 (no supported by napari anymore anyways), add 3.12, which is fully supported by napari, and also run tests on macOS-latest, which is arm64 macOS.

Should we update the python requirements to >3.9?