### PR TITLE
Fix tests on py3.11+: Update setup.cfg to block zarr >3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
 	scipy
 	superqt
 	vispy
-	zarr
+	zarr<3
 
 include_package_data = True
 


### PR DESCRIPTION
On py3.11 we're getting zarr v3 and the n3d implementations doesn't support it, so all the zarr related tests are failing.
Other things do work fine though.
Anyhow, to fix CI, I suggest using <3 for zarr for the time being.
Note a lot of the ecosystem doesn't support it, including ome-zarr-py:
https://github.com/ome/ome-zarr-py/blob/efe0391202000b5bd7e0c8ef6f07cc0481f35fc8/pyproject.toml#L22