### PR TITLE
[maint] Update mkdocs.yml to try to fix docs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,7 +122,6 @@ plugins:
           options:
             docstring_style: numpy
             filters: [ "!^_" ]
-          rendering:
             show_root_heading: true
             show_root_toc_entry: true
             show_root_full_path: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,9 +117,9 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
-          selection:
+          options:
             docstring_style: numpy
             filters: [ "!^_" ]
           rendering:


### PR DESCRIPTION
Doc builds are failing:
https://github.com/napari-threedee/napari-threedee/actions/runs/14581832216/job/40900145038

I think I have things updated correctly for the newer version of mkdocs/mkdocstrings