### PR TITLE
fix canvas change and bump napari pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
 	magicgui
 	morphosamplers
 	mrcfile
-	napari
+	napari>=0.5.0
 	numpy
 	pandas
 	pooch

--- a/src/napari_threedee/utils/napari_utils.py
+++ b/src/napari_threedee/utils/napari_utils.py
@@ -59,10 +59,8 @@ def get_vispy_root_node(viewer: napari.Viewer, layer):
 
     This is the node that layers are added to.
     """
-    # this will need to be updated in napari 0.5.0
-    # viewer.window._qt_window._qt_viewer.canvas.view.scene
     qt_viewer = viewer.window._qt_window._qt_viewer
-    return qt_viewer.view.scene
+    return qt_viewer.canvas.view.scene
 
 
 def remove_mouse_callback_safe(callback_list, callback):


### PR DESCRIPTION
Closes https://github.com/napari-threedee/napari-threedee/issues/262

in napari 0.5.0 the refactoring of the canvas has begun.
This PR uses the new (still private) API in place of the old, which was deprecated in 0.5.0 and removed in 0.6.0
As a result, I also pin the minimum napari version to 0.5.0

I tested locally and it's working. Let's see what CI says.