### PR TITLE
Added permissions for publishing to pypi

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -109,6 +109,14 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPi
+      # see https://docs.pypi.org/trusted-publishers/
+      id-token: write
+      # This permission allows writing releases
+      contents: write
+    
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Added lines to workflow as suggested in #269 using code from [https://github.com/teamtomo/torch-find-peaks/blob/6a6fa1cf0c2854e4dfe6e162e02c0b2428eb6859/.github/workflows/ci.yml#L74-L85](url) in order to ensure that PyPI changes can be made successfully.